### PR TITLE
Add percentages to success/failure outputs

### DIFF
--- a/cli/crawl-cli.js
+++ b/cli/crawl-cli.js
@@ -144,8 +144,8 @@ async function run(inputUrls, outputPath, verbose, logPath, numberOfCrawlers, da
     const endTime = new Date();
 
     log(chalk.cyan(`Finish time: ${endTime.toUTCString()}`));
-    log(chalk.cyan(`Sucessful crawls: ${successes}/${urls.length}`));
-    log(chalk.cyan(`Failed crawls: ${failures}/${urls.length}`));
+    log(chalk.cyan(`Sucessful crawls: ${successes}/${urls.length} (${(successes / urls.length * 100).toFixed(2)}%)`));
+    log(chalk.cyan(`Failed crawls: ${failures}/${urls.length} (${(failures / urls.length * 100).toFixed(2)}%)`));
 
     createMetadataFile(outputPath, {
         startTime,


### PR DESCRIPTION
**Reviewer:** @jdorweiler 
**CC:** @kdzwinel 

## Description:
I figured it'd be nice to have percentages next to successful/failed crawls for when the crawler finishes. When crawling large data sets the percentages become more meaningful of how much of the data set is not being crawled.

## Steps to test this PR:
Run the crawler on any set of data and verify the percentages printed out are correct.

## Reviewer Checklist:
- [ ] Ensure the PR solves the problem
- [ ] Review every line of code
- [ ] Ensure the PR does no harm by testing the changes thoroughly
- [ ] Get help if you're uncomfortable with any of the above!
- [ ] Determine if there are any quick wins that improve the implementation
## PR Author Checklist:
- [ ] Get advice or leverage existing code
- [ ] Agree on technical approach with reviewer (if the changes are nuanced)
- [ ] Ensure that there is a testing strategy (and documented non-automated tests)
- [ ] Ensure there is a documented monitoring strategy (if necessary)
- [ ] Consider systems implications
