### PR TITLE
[🔥Hotfix] same collector being reused for all crawls.

### DIFF
--- a/crawlerConductor.js
+++ b/crawlerConductor.js
@@ -31,7 +31,8 @@ async function crawlAndSaveData(urlString, dataCollectors, idx, log, filterOutFi
 
     const data = await crawl(url, {
         log: prefixedLog,
-        collectors: dataCollectors,
+        // @ts-ignore
+        collectors: dataCollectors.map(collector => new collector.constructor()),
         rank: idx + 1,
         filterOutFirstParty,
         emulateMobile,


### PR DESCRIPTION
In https://github.com/duckduckgo/tracker-radar-collector/commit/adef138826303f5a867326196ee4fed44de7284e I broke multithreaded crawling. Same collector instances were used for different crawls mixing up the output data. This hotfix fixes the issue, https://github.com/duckduckgo/tracker-radar-collector/issues/23 will track a proper fix that should follow.