### PR TITLE
Earlier target monitoring

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -151,9 +151,10 @@ async function getSiteData(context, url, {
 
     // Create a new page in a pristine context.
     const page = await context.newPage();
-    // @ts-ignore we are using private API to get access to CDP connection before target is created
-    // if we create a new connection only after target is created we will miss some requests, API calls, etc.
-    const cdpClient = page._client;
+
+    // @ts-ignore we are creating CDP connection before page target is created, if we create it only after
+    // new target is created we will miss some requests, API calls, etc.
+    const cdpClient = await page.target().createCDPSession();
 
     const initPageTimer = createTimer();
     for (let collector of collectors) {

--- a/crawler.js
+++ b/crawler.js
@@ -152,7 +152,7 @@ async function getSiteData(context, url, {
     // Create a new page in a pristine context.
     const page = await context.newPage();
 
-    // @ts-ignore we are creating CDP connection before page target is created, if we create it only after
+    // We are creating CDP connection before page target is created, if we create it only after
     // new target is created we will miss some requests, API calls, etc.
     const cdpClient = await page.target().createCDPSession();
 

--- a/tests/integration/crawlerConductor.test.js
+++ b/tests/integration/crawlerConductor.test.js
@@ -5,7 +5,7 @@ const {createCollector} = require('../../helpers/collectorsList');
 const testURLs = [
     'https://example.com/',
     'https://duck.com/',
-    'https://duckduckgo.github.io/privacy-test-pages/trackers/1major-via-script.html',
+    'https://privacy-test-pages.glitch.me/tracker-reporting/1major-via-script.html',
     'https://fingerprintjs.com/demo/'
 ];
 
@@ -89,8 +89,8 @@ async function main() {
 
     assert(Object.keys(duckCom.data.apis.callStats).length > 0, 'duck.com does execute some JS and callStats should NOT be empty');
 
-    /// https://duckduckgo.github.io/privacy-test-pages/trackers/1major-via-script.html tests
-    const privacyTestPages1 = data.find(d => d.initialUrl === 'https://duckduckgo.github.io/privacy-test-pages/trackers/1major-via-script.html');
+    /// https://privacy-test-pages.glitch.me/tracker-reporting/1major-via-script.html tests
+    const privacyTestPages1 = data.find(d => d.initialUrl === 'https://privacy-test-pages.glitch.me/tracker-reporting/1major-via-script.html');
     commonTests(privacyTestPages1, 'privacy-test-pages/1major-via-script');
 
     assert(privacyTestPages1.data.requests.length === 2, 'privacy-test-pages/1major-via-script does load one subresource and one main page document');
@@ -106,9 +106,14 @@ async function main() {
     const fingerprintjsThirdPartyRequsts = fingerprintjs.data.requests.filter((/** @type {{url:string}} **/ r) => !new URL(r.url).hostname.endsWith('fingerprintjs.com'));
     assert(fingerprintjsThirdPartyRequsts.length > 2, `fingerprintjs.com loads multiple third parties`);
 
-    const apis = fingerprintjs.data.apis.callStats['https://fingerprintjs.com/dist/demo.js'];
-    assert(Object.keys(apis).length > 15, 'fingerprintjs.com demo script touches over 15 APIs');
-    assert(apis['HTMLCanvasElement.prototype.toDataURL'] > 0, 'fingerprintjs.com demo script touches canvas API');
+    /**
+     * @type {Array<string>}
+     */
+    const apis = [];
+    const scripts = Object.keys(fingerprintjs.data.apis.callStats);
+    scripts.forEach(src => Object.keys(fingerprintjs.data.apis.callStats[src]).forEach(api => apis.push(api)));
+    assert(apis.length > 15, 'fingerprintjs.com demo script touches over 15 APIs');
+    assert(apis.includes('HTMLCanvasElement.prototype.toDataURL'), 'fingerprintjs.com demo script touches canvas API');
 
     assert(fingerprintjs.data.targets.length > 0, 'fingerprintjs.com does have multiple targets - main frame + blobs');
 


### PR DESCRIPTION
Creating new Chrome Debugging Protocol session only after target is created causes us to miss some early requests and API calls. This is reproducible when crawling with multiple concurrent crawlers. To avoid that, we create CDP session before the page is created.

In the long run we should fix that by requiring all targets to wait for debugger (via https://vanilla.aslushnikov.com/?Target.setAutoAttach) but it doesn't seem to work right now (requires additional investigation / ditching puppeteer).

I tested it by running:

```npm run crawl -- -i ./data/cards/urls.txt -c 20  -o ./data/cards -d 'apis,cookies,requests,targets' -f -l ./data/cards/log.txt```

and validating the results with

```js
const fs = require('fs');
const path = require('path');
const dirPath = './cards/';

fs.readdirSync(dirPath).forEach(file => {
    if (file === 'metadata.json' || !file.endsWith('.json')) {
        return;
    }

    const filePath = path.join(dirPath, file);
    const fileText = fs.readFileSync(filePath);

    const data = JSON.parse(fileText);

    const requests = data.data.requests.map(r => r.url);
    const apiScripts = Object.keys(data.data.apis.callStats);
    const savedScripts = data.data.apis.savedCalls.map(c => c.source);

    const missingScripts = (apiScripts.concat(savedScripts)).filter(s => !requests.includes(s));

    console.log(file, missingScripts);
});
```

On the main branch scripts are consistently missed. On this branch nothing gets missed.

This also fixes #8.