### PR TITLE
Earlier target monitoring

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -158,7 +158,7 @@ async function getSiteData(context, url, {
     // Create a new page in a pristine context.
     const page = await context.newPage();
 
-    // @ts-ignore we are creating CDP connection before page target is created, if we create it only after
+    // We are creating CDP connection before page target is created, if we create it only after
     // new target is created we will miss some requests, API calls, etc.
     const cdpClient = await page.target().createCDPSession();
 

--- a/crawler.js
+++ b/crawler.js
@@ -162,6 +162,9 @@ async function getSiteData(context, url, {
     // new target is created we will miss some requests, API calls, etc.
     const cdpClient = await page.target().createCDPSession();
 
+    // without this, we will miss the initial request for the web worker or service worker file
+    await cdpClient.send('Target.setAutoAttach', {autoAttach: true, waitForDebuggerOnStart: true});
+
     const initPageTimer = createTimer();
     for (let collector of collectors) {
         try {

--- a/crawler.js
+++ b/crawler.js
@@ -157,9 +157,10 @@ async function getSiteData(context, url, {
 
     // Create a new page in a pristine context.
     const page = await context.newPage();
-    // @ts-ignore we are using private API to get access to CDP connection before target is created
-    // if we create a new connection only after target is created we will miss some requests, API calls, etc.
-    const cdpClient = page._client;
+
+    // @ts-ignore we are creating CDP connection before page target is created, if we create it only after
+    // new target is created we will miss some requests, API calls, etc.
+    const cdpClient = await page.target().createCDPSession();
 
     const initPageTimer = createTimer();
     for (let collector of collectors) {

--- a/crawler.js
+++ b/crawler.js
@@ -176,21 +176,6 @@ async function getSiteData(context, url, {
     }
     log(`page context initiated in ${initPageTimer.getElapsedTime()}s`);
 
-    // We are creating CDP connection before page target is created, if we create it only after
-    // new target is created we will miss some requests, API calls, etc.
-    const cdpClient = await page.target().createCDPSession();
-
-    const initPageTimer = createTimer();
-    for (let collector of collectors) {
-        try {
-            // eslint-disable-next-line no-await-in-loop
-            await collector.addTarget({url: url.toString(), type: 'page', cdpClient});
-        } catch (e) {
-            log(chalk.yellow(`${collector.id()} failed to attach to page`), chalk.gray(e.message), chalk.gray(e.stack));
-        }
-    }
-    log(`page context initiated in ${initPageTimer.getElapsedTime()}s`);
-
     if (emulateUserAgent) {
         page.setUserAgent(emulateMobile ? MOBILE_USER_AGENT : DEFAULT_USER_AGENT);
     }

--- a/tests/integration/apiCollection.test.js
+++ b/tests/integration/apiCollection.test.js
@@ -19,7 +19,6 @@ async function main() {
         "PerformanceTiming.prototype.navigationStart",
         "Document.cookie getter",
         "Document.cookie setter",
-        "Document.interestCohort",
         "Navigator.prototype.onLine",
         "Navigator.prototype.keyboard",
         "Navigator.prototype.presentation",
@@ -46,6 +45,7 @@ async function main() {
         "Gyroscope.prototype.y",
         "Gyroscope.prototype.z",
         // method calls
+        "Document.prototype.interestCohort",
         'window.matchMedia("prefers-color-scheme")',
         'HTMLCanvasElement.prototype.constructor',
         'CanvasRenderingContext2D.prototype.isPointInPath',

--- a/tests/integration/apiCollection.test.js
+++ b/tests/integration/apiCollection.test.js
@@ -1,0 +1,93 @@
+const {crawler, APICallCollector} = require('../../main.js');
+const assert = require('assert');
+const breakpoints = require('../../collectors/APICalls/breakpoints.js');
+
+async function main() {
+
+    // we are testing all APIs that we are monitoring against our privacy test page for fingerprinting
+
+    const apiData = await crawler(new URL('https://privacy-test-pages.glitch.me/privacy-protections/fingerprinting/?run'), {
+        log: () => {},
+        collectors: [new APICallCollector()]
+    });
+
+    const apiCalls = apiData.data.apis.callStats['https://privacy-test-pages.glitch.me/privacy-protections/fingerprinting/helpers/tests.js'];
+
+    // known fingerprinting breakpoints that are not invoked by our test page
+    const knownMissing = [
+        "window.name",
+        "PerformanceTiming.prototype.navigationStart",
+        "Document.cookie getter",
+        "Document.cookie setter",
+        "Document.interestCohort",
+        "Navigator.prototype.onLine",
+        "Navigator.prototype.keyboard",
+        "Navigator.prototype.presentation",
+        "Event.prototype.timeStamp",
+        "KeyboardEvent.prototype.code",
+        "KeyboardEvent.prototype.keyCode",
+        "Touch.prototype.force",
+        "Touch.prototype.radiusX",
+        "Touch.prototype.radiusY",
+        "Touch.prototype.rotationAngle",
+        "WheelEvent.prototype.deltaX",
+        "WheelEvent.prototype.deltaY",
+        "WheelEvent.prototype.deltaZ",
+        "DeviceOrientationEvent.prototype.alpha",
+        "DeviceOrientationEvent.prototype.beta",
+        "DeviceOrientationEvent.prototype.gamma",
+        "DeviceOrientationEvent.prototype.absolute",
+        "DeviceMotionEvent.prototype.acceleration",
+        "DeviceMotionEvent.prototype.accelerationIncludingGravity",
+        "DeviceMotionEvent.prototype.rotationRate",
+        "Animation.prototype.currentTime",
+        "Animation.prototype.startTime",
+        "Gyroscope.prototype.x",
+        "Gyroscope.prototype.y",
+        "Gyroscope.prototype.z",
+        // method calls
+        'window.matchMedia("prefers-color-scheme")',
+        'HTMLCanvasElement.prototype.constructor',
+        'CanvasRenderingContext2D.prototype.isPointInPath',
+        'Date.prototype.getTime',
+        'WebGLRenderingContext.prototype.getExtension',
+        'AudioWorkletNode.prototype.constructor',
+        'SharedWorker.prototype.constructor',
+        'BroadcastChannel.prototype.constructor',
+        'TouchEvent.prototype.constructor',
+        'URL.createObjectURL',
+        'CSSStyleDeclaration.setProperty("fontFamily",…)',
+        'Element.prototype.getClientRects',
+        'Sensor.prototype.constructor',
+    ];
+
+    breakpoints.forEach(object => {
+        /**
+         * @type {string}
+         */
+        let prefix;
+
+        if (object.proto) {
+            prefix = object.proto + '.prototype.';
+        } else if (object.global) {
+            prefix = object.global + '.';
+        }
+
+        object.props.forEach(prop => {
+            const propName = prop.description || (prefix + prop.name);
+
+            if (!apiCalls[propName] && !knownMissing.includes(propName)) {
+                assert(false, `Missing ${propName} property read.`);
+            }
+        });
+        object.methods.forEach(method => {
+            const methodName = method.description || (prefix + method.name);
+
+            if (!apiCalls[methodName] && !knownMissing.includes(methodName)) {
+                assert(false, `Missing ${methodName} method call.`);
+            }
+        });
+    });
+}
+
+main();

--- a/tests/integration/requestCollection.test.js
+++ b/tests/integration/requestCollection.test.js
@@ -1,0 +1,26 @@
+const {crawler, RequestCollector} = require('../../main.js');
+const assert = require('assert');
+
+async function main() {
+
+    const requestData = await crawler(new URL('https://privacy-test-pages.glitch.me/privacy-protections/request-blocking/?run'), {
+        log: () => {},
+        collectors: [new RequestCollector()]
+    });
+
+    // we are testing edge cases - requests that we missed in the past
+
+    const serviceWorkerRequest = requestData.data.requests.find((/** @type {{url: string}} **/ r) => r.url.endsWith('/service-worker.js'));
+    
+    assert(serviceWorkerRequest, 'Service worker request captured.');
+    
+    const webWorkerRequest = requestData.data.requests.find((/** @type {{url: string}} **/ r) => r.url.endsWith('/worker.js'));
+
+    assert(webWorkerRequest, 'Web worker request captured.');
+
+    const cspRequest = requestData.data.requests.find((/** @type {{url: string}} **/ r) => r.url.endsWith('/csp'));
+
+    assert(cspRequest, 'CSP report request captured.');
+}
+
+main();


### PR DESCRIPTION
We were missing some requests because instrumentation was ready only couple of ms after new context (such as main page context, service worker, etc.) were created.

I also added integration tests for api call and request collection.