### PR TITLE
Support for `--chromium-version` custom versions of Chromium

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Available options:
 - `-p, --proxy-config <host>` - optional SOCKS proxy host
 - `-r, --region-code <region>` - optional 2 letter region code. For metadata only
 - `-a, --disable-anti-bot` - disable simple build-in anti bot detection script injected to every frame
+- `--chromium-version <version_number>` - use custom version of Chromium (e.g. "843427") instead of using the default
 
 ### Use it as a module
 
@@ -61,6 +62,7 @@ crawlerConductor({
     emulateMobile: true,// emulate a mobile device (false by default)
     proxyHost: 'socks5://myproxy:8080',// SOCKS proxy host (none by default)
     antiBotDetection: true,// if anti bot detection script should be injected (true by default)
+    chromiumVersion: '843427',// Chromium version that should be downloaded and used instad of the default one
 });
 ```
 
@@ -78,6 +80,7 @@ const data = await crawler(new URL('https://example.com'), {
     proxyHost: 'socks5://myproxy:8080',
     browserContext: context,// if you prefer to create the browser context yourself (to e.g. use other browser or non-incognito context) you can pass it here (by default crawler will create an incognito context using standard chromium for you)
     runInEveryFrame: () => {window.alert('injected')},// function that should be executed in every frame (main + all subframes)
+    executablePath: '/some/path/Chromium.app/Contents/MacOS/Chromium',//path to a custom Chromium installation that should be used instad of the default one
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ crawlerConductor({
     emulateMobile: true,// emulate a mobile device (false by default)
     proxyHost: 'socks5://myproxy:8080',// SOCKS proxy host (none by default)
     antiBotDetection: true,// if anti bot detection script should be injected (true by default)
-    chromiumVersion: '843427',// Chromium version that should be downloaded and used instad of the default one
+    chromiumVersion: '843427',// Chromium version that should be downloaded and used instead of the default one
 });
 ```
 
@@ -80,7 +80,7 @@ const data = await crawler(new URL('https://example.com'), {
     proxyHost: 'socks5://myproxy:8080',
     browserContext: context,// if you prefer to create the browser context yourself (to e.g. use other browser or non-incognito context) you can pass it here (by default crawler will create an incognito context using standard chromium for you)
     runInEveryFrame: () => {window.alert('injected')},// function that should be executed in every frame (main + all subframes)
-    executablePath: '/some/path/Chromium.app/Contents/MacOS/Chromium',//path to a custom Chromium installation that should be used instad of the default one
+    executablePath: '/some/path/Chromium.app/Contents/MacOS/Chromium',// path to a custom Chromium installation that should be used instead of the default one
 });
 ```
 

--- a/cli/crawl-cli.js
+++ b/cli/crawl-cli.js
@@ -25,6 +25,7 @@ program
     .option('-p, --proxy-config <host>', 'use an optional proxy configuration')
     .option('-r, --region-code <region>', 'optional 2 letter region code. Used for metadata only.')
     .option('-a, --disable-anti-bot', 'disable anti bot detection protections injected to every frame')
+    .option('--chromium-version <version_number>', 'use custom version of chromium')
     .parse(process.argv);
 
 /**
@@ -40,8 +41,9 @@ program
  * @param {string} proxyHost
  * @param {string} regionCode
  * @param {boolean} antiBotDetection
+ * @param {string} chromiumVersion
  */
-async function run(inputUrls, outputPath, verbose, logPath, numberOfCrawlers, dataCollectors, forceOverwrite, filterOutFirstParty, emulateMobile, proxyHost, regionCode, antiBotDetection) {
+async function run(inputUrls, outputPath, verbose, logPath, numberOfCrawlers, dataCollectors, forceOverwrite, filterOutFirstParty, emulateMobile, proxyHost, regionCode, antiBotDetection, chromiumVersion) {
     const logFile = logPath ? fs.createWriteStream(logPath, {flags: 'w'}) : null;
 
     /**
@@ -155,7 +157,8 @@ async function run(inputUrls, outputPath, verbose, logPath, numberOfCrawlers, da
             filterOutFirstParty,
             emulateMobile,
             proxyHost,
-            antiBotDetection
+            antiBotDetection,
+            chromiumVersion
         });
         log(chalk.green('\n✅ Finished successfully.'));
     } catch(e) {
@@ -240,5 +243,5 @@ if (!urls || !program.output) {
         fs.mkdirSync(program.output);
     }
 
-    run(urls, program.output, verbose, program.logFile, program.crawlers || null, dataCollectors, forceOverwrite, filterOutFirstParty, emulateMobile, program.proxyConfig, program.regionCode, !program.disableAntiBot);
+    run(urls, program.output, verbose, program.logFile, program.crawlers || null, dataCollectors, forceOverwrite, filterOutFirstParty, emulateMobile, program.proxyConfig, program.regionCode, !program.disableAntiBot, program.chromiumVersion);
 }

--- a/crawler.js
+++ b/crawler.js
@@ -30,8 +30,9 @@ const VISUAL_DEBUG = false;
 /**
  * @param {function(...any):void} log
  * @param {string} proxyHost
+ * @param {string} executablePath path to chromium executable to use
  */
-function openBrowser(log, proxyHost) {
+function openBrowser(log, proxyHost, executablePath) {
     /**
      * @type {import('puppeteer').BrowserLaunchArgumentOptions}
      */
@@ -57,9 +58,10 @@ function openBrowser(log, proxyHost) {
         args.args.push(`--proxy-server=${proxyHost}`);
         args.args.push(`--host-resolver-rules="MAP * ~NOTFOUND , EXCLUDE ${url.hostname}"`);
     }
-
-    // for debugging: use different version of Chromium/Chrome
-    // args.executablePath = "/Applications/Google\ Chrome\ Canary.app/Contents/MacOS/Google\ Chrome\ Canary";
+    if (executablePath) {
+        // @ts-ignore there is no single object that encapsulates properties of both BrowserLaunchArgumentOptions and LaunchOptions that are allowed here
+        args.executablePath = executablePath;
+    }
 
     return puppeteer.launch(args);
 }
@@ -275,12 +277,12 @@ function isThirdPartyRequest(documentUrl, requestUrl) {
 
 /**
  * @param {URL} url
- * @param {{collectors?: import('./collectors/BaseCollector')[], log?: function(...any):void, filterOutFirstParty?: boolean, emulateMobile?: boolean, emulateUserAgent?: boolean, proxyHost?: string, browserContext?: puppeteer.BrowserContext, runInEveryFrame?: function():void}} options
+ * @param {{collectors?: import('./collectors/BaseCollector')[], log?: function(...any):void, filterOutFirstParty?: boolean, emulateMobile?: boolean, emulateUserAgent?: boolean, proxyHost?: string, browserContext?: puppeteer.BrowserContext, runInEveryFrame?: function():void, executablePath?: string}} options
  * @returns {Promise<CollectResult>}
  */
 module.exports = async (url, options) => {
     const log = options.log || (() => {});
-    const browser = options.browserContext ? null : await openBrowser(log, options.proxyHost);
+    const browser = options.browserContext ? null : await openBrowser(log, options.proxyHost, options.executablePath);
     // Create a new incognito browser context.
     const context = options.browserContext || await browser.createIncognitoBrowserContext();
 

--- a/helpers/downloadCustomChromium.js
+++ b/helpers/downloadCustomChromium.js
@@ -1,0 +1,25 @@
+const puppeteer = require('puppeteer');
+const ProgressBar = require('progress');
+const chalk = require('chalk').default;
+
+/**
+ * @param {function} log
+ * @param {string} version 
+ * @returns {Promise<string>} executable path of the downloaded Chromium
+ */
+async function downloadCustomChromium(log, version) {
+    const browserFetcher = puppeteer.createBrowserFetcher();
+    const canDownload = await browserFetcher.canDownload(version);
+
+    if (!canDownload) {
+        throw new Error(`Provided version of Chromium (${version}) can't be downloaded.`);
+    }
+
+    log(chalk.blue(`⬇ Downloading custom version of Chromium - ${version}.`));
+    const progressBar = new ProgressBar('[:bar] :percent ETA :etas', {total: 100, width: 30});
+    const revisionInfo = await browserFetcher.download(version, (/** @type {number} **/current, /** @type {number} **/total) => progressBar.update(current / total));
+
+    return revisionInfo.executablePath;
+}
+
+module.exports = downloadCustomChromium;

--- a/helpers/downloadCustomChromium.js
+++ b/helpers/downloadCustomChromium.js
@@ -8,6 +8,7 @@ const chalk = require('chalk').default;
  * @returns {Promise<string>} executable path of the downloaded Chromium
  */
 async function downloadCustomChromium(log, version) {
+    // @ts-ignore for some reason createBrowserFetcher is missing from the typescript definition?
     const browserFetcher = puppeteer.createBrowserFetcher();
     const canDownload = await browserFetcher.canDownload(version);
 

--- a/helpers/downloadCustomChromium.js
+++ b/helpers/downloadCustomChromium.js
@@ -8,6 +8,9 @@ const chalk = require('chalk').default;
  * @returns {Promise<string>} executable path of the downloaded Chromium
  */
 async function downloadCustomChromium(log, version) {
+    /**
+     * @type {import('puppeteer').BrowserFetcher}
+     */
     // @ts-ignore for some reason createBrowserFetcher is missing from the typescript definition?
     const browserFetcher = puppeteer.createBrowserFetcher();
     const canDownload = await browserFetcher.canDownload(version);


### PR DESCRIPTION
We've seen a slowdown in the latest crawls and would like to experiment with crawling with non-default versions of Chromium, this flag provides this ability.