### PR TITLE
Add html summary and screenshot options

### DIFF
--- a/cli/crawl-cli.js
+++ b/cli/crawl-cli.js
@@ -158,7 +158,7 @@ async function run(inputUrls, outputPath, verbose, logPath, numberOfCrawlers, da
         }
 
         // rewrite metadata page every 1%
-        if (program.htmlLog && (successes + failures) % 1 === 0) {
+        if (program.htmlLog && ((successes + failures) / urls.length)*100 % 1 === 0) {
             createMetadataHTML(outputPath, {
                 startTime,
                 crawlTimes,
@@ -278,7 +278,9 @@ if (!urls || !program.output) {
         console.log(chalk.red('Screenshot folder already exists'), 'Use -f to overwrite.');
     } else if (program.screenshotLogging) {
         screenshotHelper.loadScreenshotList(program.screenshotLogging);
-        fs.mkdirSync(`${program.output}/screenshots`);
+        if (!fs.existsSync(`${program.output}/screenshots`)) {
+            fs.mkdirSync(`${program.output}/screenshots`);
+        }
     }
 
     if (fs.existsSync(program.output)) {

--- a/cli/crawl-cli.js
+++ b/cli/crawl-cli.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const fs = require('fs');
+const fs = require('fs-extra');
 const chalk = require('chalk').default;
 const runCrawlers = require('../crawlerConductor');
 const program = require('commander');
@@ -151,7 +151,7 @@ async function run(inputUrls, outputPath, verbose, logPath, numberOfCrawlers, da
         // temp name for the screenshot is scored in data. rename the screenshot to match the file crawl file
         if (data.data.screenshot) {
             const screenshotFilename = `${outputPath}/screenshots/${url.hostname}_${outputFile.match(/_([a-z0-9]{4})\.json/)[1]}.jpg`;
-            fs.rename(data.data.screenshot, screenshotFilename, err => {
+            fs.move(data.data.screenshot, screenshotFilename, err => {
                 log(err);
             });
             screenshotHelper.rebuildIndex(outputPath);

--- a/cli/crawl-cli.js
+++ b/cli/crawl-cli.js
@@ -109,7 +109,15 @@ async function run(inputUrls, outputPath, verbose, logPath, numberOfCrawlers, da
 
     let failures = 0;
     let successes = 0;
+
+    /**
+     * @type {Error}
+     */
     let fatalError = null;
+
+    /**
+     * @type {Array<Array<number>>}
+     */
     let crawlTimes = [];
     
     const startTime = new Date();
@@ -129,7 +137,7 @@ async function run(inputUrls, outputPath, verbose, logPath, numberOfCrawlers, da
 
     /**
      * @param {URL} url
-     * @param {object} data
+     * @param {{testStarted: number, testFinished: number, data: {screenshot: string}}} data
      */
     const dataCallback = (url, data) => {
         successes++;

--- a/cli/metadataFile.js
+++ b/cli/metadataFile.js
@@ -49,7 +49,7 @@ function createMetadataFile(outputPath, {startTime, endTime, urls, successes, fa
 }
 
 /**
- * @param {string} dateString
+ * @param {number} dateString
  * @return {string}
  */
 function _getTimeBucket (dateString) {
@@ -59,11 +59,13 @@ function _getTimeBucket (dateString) {
 
 /**
  * @param {string} outputPath
- * @param {{crawlTimes: number[], startTime: Date, urls: number, successes: number, failures: number, skipped: number, numberOfCrawlers: number, regionCode: string, fatalError: Error}} data
+ * @param {{crawlTimes: number[][], startTime: Date, urls: number, successes: number, failures: number, skipped: number, numberOfCrawlers: number, regionCode: string, fatalError: Error}} data
  */
 function createMetadataHTML(outputPath, {startTime, crawlTimes, fatalError, numberOfCrawlers, regionCode, successes, failures, urls, skipped}) {
+    /** @type {Object.<string, number>} */
     let minuteBuckets = {};
 
+    /** @type {{sites: number, total: number}}*/
     const crawlStats = crawlTimes.reduce((stats, siteTime) => {
         stats.sites++;
         stats.total += siteTime[2];

--- a/cli/metadataFile.js
+++ b/cli/metadataFile.js
@@ -48,8 +48,62 @@ function createMetadataFile(outputPath, {startTime, endTime, urls, successes, fa
     }, null, 2));
 }
 
+function _getTimeBucket (dateString) {
+    const date = new Date(dateString);
+    return `${date.getMonth()}/${date.getDay()}/${date.getHours()}:${date.getMinutes()}`;
+}
+
+/**
+ * @param {string} outputPath
+ * @param {{startTime: Date, endTime: Date, urls: number, successes: number, failures: number, skipped: number, numberOfCrawlers: number, regionCode: string, fatalError: Error}} data
+ */
+function createMetadataHTML(outputPath, {startTime, crawlTimes, fatalError, numberOfCrawlers, regionCode, successes, failures, urls, skipped}) {
+    try {
+        let minuteBuckets = {};
+
+        const crawlStats = crawlTimes.reduce((stats, siteTime) => {
+            stats.sites++;
+            stats.total += siteTime[2];
+
+            const timeBucketKey = _getTimeBucket(siteTime[1]);
+            if (minuteBuckets[timeBucketKey]) {
+                minuteBuckets[timeBucketKey]++;
+            } else {
+                minuteBuckets[timeBucketKey] = 1;
+            }
+
+            return stats;
+        }, {sites: 0, total: 0});
+
+        const crawlRate = crawlStats.sites / Object.keys(minuteBuckets).length;
+        const finishTime = new Date();
+        finishTime.setMinutes(finishTime.getMinutes() + ((urls - (successes + failures + skipped)) / crawlRate));
+
+        const html = `<html>
+    <head>
+        <title>Crawler status</title>
+    </head>
+    <body>
+        <p>Status: crawling site ${successes + failures} of ${urls}</p>
+        <p>Avg site load time: ${((crawlStats.total / crawlStats.sites) / 1000).toFixed(1)} sec</p>
+        <p>Avg crawl rate: ${crawlRate.toFixed(1)} sites/min with ${numberOfCrawlers} crawlers</p>
+        <p>Estimated completion time: ${finishTime.toString()}</p>
+        <p>Region: ${regionCode ? regionCode : "US"}</p>
+        <p>Crawl started: ${startTime}</p>
+        <p>Last update: ${new Date()}</p>
+        <p>Errors: ${fatalError ? fatalError : 'None'}</p>
+        <a href="/screenshots/index.html?a=${Math.floor(Math.random() * 10000000)}">Screenshots</a>
+    </body>
+    </html>`;
+
+        fs.writeFileSync(`${outputPath}/index.html`, html);
+    } catch (e) {
+        console.log(e);
+    }
+}
 
 module.exports = {
     createMetadataFile,
-    metadataFileExists
+    metadataFileExists,
+    createMetadataHTML
 };

--- a/cli/metadataFile.js
+++ b/cli/metadataFile.js
@@ -96,7 +96,7 @@ function createMetadataHTML(outputPath, {startTime, crawlTimes, fatalError, numb
         <p>Crawl started: ${startTime}</p>
         <p>Last update: ${new Date()}</p>
         <p>Errors: ${fatalError ? fatalError : 'None'}</p>
-        <a href="/screenshots/index.html?a=${Math.floor(Math.random() * 10000000)}">Screenshots</a>
+        <a href="./screenshots/index.html?a=${Math.floor(Math.random() * 10000000)}">Screenshots</a>
     </body>
     </html>`;
 

--- a/crawler.js
+++ b/crawler.js
@@ -69,7 +69,7 @@ function openBrowser(log, proxyHost, executablePath) {
 /**
  * @param {puppeteer.BrowserContext} context
  * @param {URL} url
- * @param {{collectors: import('./collectors/BaseCollector')[], log: function(...any):void, urlFilter: function(string, string):boolean, emulateMobile: boolean, emulateUserAgent: boolean, runInEveryFrame: function():void}} data
+ * @param {{collectors: import('./collectors/BaseCollector')[], log: function(...any):void, urlFilter: function(string, string):boolean, emulateMobile: boolean, emulateUserAgent: boolean, runInEveryFrame: function():void, getScreenshot: boolean}} data
  *
  * @returns {Promise<CollectResult>}
  */
@@ -283,7 +283,7 @@ function isThirdPartyRequest(documentUrl, requestUrl) {
 
 /**
  * @param {URL} url
- * @param {{collectors?: import('./collectors/BaseCollector')[], log?: function(...any):void, filterOutFirstParty?: boolean, emulateMobile?: boolean, emulateUserAgent?: boolean, proxyHost?: string, browserContext?: puppeteer.BrowserContext, runInEveryFrame?: function():void, executablePath?: string}} options
+ * @param {{collectors?: import('./collectors/BaseCollector')[], log?: function(...any):void, filterOutFirstParty?: boolean, emulateMobile?: boolean, emulateUserAgent?: boolean, proxyHost?: string, browserContext?: puppeteer.BrowserContext, runInEveryFrame?: function():void, executablePath?: string, getScreenshot?: boolean}} options
  * @returns {Promise<CollectResult>}
  */
 module.exports = async (url, options) => {

--- a/crawler.js
+++ b/crawler.js
@@ -79,7 +79,8 @@ async function getSiteData(context, url, {
     urlFilter,
     emulateUserAgent,
     emulateMobile,
-    runInEveryFrame
+    runInEveryFrame,
+    getScreenshot
 }) {
     const testStarted = Date.now();
 
@@ -251,6 +252,11 @@ async function getSiteData(context, url, {
     }
 
     if (!VISUAL_DEBUG) {
+        if (getScreenshot) {
+            const screenshotFilename = `${Math.random().toString().substr(2, 8)}.jpg`;
+            await page.screenshot({path: screenshotFilename, type: 'jpeg'});
+            data.screenshot = screenshotFilename;
+        }
         await page.close();
     }
 
@@ -295,7 +301,8 @@ module.exports = async (url, options) => {
             urlFilter: options.filterOutFirstParty === true ? isThirdPartyRequest.bind(null) : null,
             emulateUserAgent: options.emulateUserAgent !== false, // true by default
             emulateMobile: options.emulateMobile,
-            runInEveryFrame: options.runInEveryFrame
+            runInEveryFrame: options.runInEveryFrame,
+            getScreenshot: options.getScreenshot
         }), MAX_TOTAL_TIME);
     } catch(e) {
         log(chalk.red('Crawl failed'), e.message, chalk.gray(e.stack));

--- a/crawlerConductor.js
+++ b/crawlerConductor.js
@@ -26,7 +26,7 @@ const MAX_NUMBER_OF_RETRIES = 2;
  * @param {string} proxyHost
  * @param {boolean} antiBotDetection
  * @param {string} executablePath
- * @param {boolean} screenshotLogging
+ * @param {string} screenshotLogging
  */
 async function crawlAndSaveData(urlString, dataCollectors, log, filterOutFirstParty, dataCallback, emulateMobile, proxyHost, antiBotDetection, executablePath, screenshotLogging) {
     const url = new URL(urlString);
@@ -51,7 +51,7 @@ async function crawlAndSaveData(urlString, dataCollectors, log, filterOutFirstPa
 }
 
 /**
- * @param {{urls: string[], dataCallback: function(URL, import('./crawler').CollectResult): void, dataCollectors?: BaseCollector[], failureCallback?: function(string, Error): void, numberOfCrawlers?: number, logFunction?: function, filterOutFirstParty: boolean, emulateMobile: boolean, proxyHost: string, antiBotDetection?: boolean, chromiumVersion?: string}} options
+ * @param {{urls: string[], dataCallback: function(URL, import('./crawler').CollectResult): void, dataCollectors?: BaseCollector[], failureCallback?: function(string, Error): void, numberOfCrawlers?: number, logFunction?: function, filterOutFirstParty: boolean, emulateMobile: boolean, proxyHost: string, antiBotDetection?: boolean, chromiumVersion?: string, screenshotLogging?: string}} options
  */
 module.exports = async options => {
     const deferred = createDeferred();
@@ -79,7 +79,7 @@ module.exports = async options => {
         log(chalk.cyan(`Processing entry #${Number(idx) + 1} (${urlString}).`));
         const timer = createTimer();
 
-        const task = crawlAndSaveData.bind(null, urlString, options.dataCollectors, log, options.filterOutFirstParty, options.dataCallback, options.emulateMobile, options.proxyHost, (options.antiBotDetection !== false), executablePath, (options.screenshotLogging !== false));
+        const task = crawlAndSaveData.bind(null, urlString, options.dataCollectors, log, options.filterOutFirstParty, options.dataCallback, options.emulateMobile, options.proxyHost, (options.antiBotDetection !== false), executablePath, options.screenshotLogging);
 
         async.retry(MAX_NUMBER_OF_RETRIES, task, err => {
             if (err) {

--- a/helpers/screenshot.js
+++ b/helpers/screenshot.js
@@ -1,0 +1,62 @@
+const fs = require('fs');
+const ALL_SCREENSHOTS = false;
+/**
+ * @type {string[]}
+ */
+let screenshotList = [];
+
+/**
+ * @param {string} filePath
+ */
+function loadScreenshotList (filePath) {
+    screenshotList = fs.readFileSync(filePath, 'utf8').split('\n').reduce((list, site) => {
+        if (site) {
+            list.push(site);
+        }
+        return list;
+    }, []);
+}
+
+/**
+ * @param {URL} url
+ * @returns {boolean}
+ */
+function shouldTakeScreenshot (url) {
+    if (ALL_SCREENSHOTS) {
+        return true;
+    }
+    return screenshotList.includes(url.hostname.replace(/^www\./, ''));
+}
+
+/**
+ * @param {string} outputPath
+ */
+function rebuildIndex (outputPath) {
+    const screenshotFiles = fs.readdirSync(`${outputPath}/screenshots`);
+    let nScreenshots = 0;
+
+    const bodyContent =screenshotFiles.reduce((str, name) => {
+        if (name.match('jpg')) {
+            nScreenshots++;
+            // eslint-disable-next-line no-param-reassign
+            str += `<p>${name.replace(/_.*\.jpg/,'')}</p><a href=${name}> <img src=${name} width="800" height="400" alt=${name}></a>`;
+        }
+        return str;
+    }, '');
+
+    const html = `<html>
+        <head><title>Crawler screenshots</title></head>
+            <body>
+                <p>Number of screenshots: ${nScreenshots}</p>
+                ${bodyContent}
+            </body>
+        </html>`;
+
+    fs.writeFileSync(`${outputPath}/screenshots/index.html`, html);
+}
+
+module.exports = {
+    loadScreenshotList,
+    shouldTakeScreenshot,
+    rebuildIndex
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -609,6 +609,16 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
+    "fs-extra": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -658,6 +668,11 @@
       "requires": {
         "type-fest": "^0.8.1"
       }
+    },
+    "graceful-fs": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
     },
     "has-flag": {
       "version": "3.0.0",
@@ -768,6 +783,15 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
     },
     "levn": {
       "version": "0.4.1",
@@ -1260,6 +1284,11 @@
         "buffer": "^5.2.1",
         "through": "^2.3.8"
       }
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "async": "^2.6.1",
     "chalk": "^2.4.1",
     "commander": "^2.19.0",
+    "fs-extra": "^10.0.0",
     "progress": "^2.0.3",
     "puppeteer": "^10.2.0",
     "tldts": "^4.0.3"


### PR DESCRIPTION
HTML output (-h or —html-log) <bool>
Screenshots (-s or —screenshot-logging) <txt of domains> 

Writes HTML summary to `<outputDir>/index.html`
Writes screenshots to `<outputDir>/screenshots/`, hostname of site must match hostname in `--screenshot-logging` file or set "All_SCREENSHOTS" to true in helpers/screenshots.js

Testing 
npm run crawl -- -o ./data/ -i listOfSites.txt -f -c 3 --html-log --screenshot-logging screenshotList.txt

<img width="920" alt="Screen Shot 2021-12-02 at 2 11 40 PM" src="https://user-images.githubusercontent.com/1882892/144518178-e36ea497-e5da-497c-b8e5-e69d1e404b79.png">
<img width="952" alt="Screen Shot 2021-12-02 at 2 11 49 PM" src="https://user-images.githubusercontent.com/1882892/144518183-08a9ce58-1622-41fc-97c8-8917cf8fbb39.png">
>
