### PR TITLE
Introduce config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Available options:
 - `-r, --region-code <region>` - optional 2 letter region code. For metadata only
 - `-a, --disable-anti-bot` - disable simple build-in anti bot detection script injected to every frame
 - `--chromium-version <version_number>` - use custom version of Chromium (e.g. "843427") instead of using the default
+- `--config <path>` - path to a config file that allows to set all the above settings (and more). Note that CLI flags have a higher priority than settings passed via config. You can find a sample config file in `tests/cli/sampleConfig.json`.
 
 ### Use it as a module
 
@@ -52,7 +53,7 @@ const {RequestCollector, CookieCollector, …} = require('tracker-radar-collecto
 ```js
 crawlerConductor({
     // required ↓
-    urls: ['https://example.com', 'https://duck.com', …],
+    urls: ['https://example.com', {url: 'https://duck.com', dataCollectors: [new ScreenshotCollector()]}, …], // two formats available: first format will use default collectors set below, second format will use custom set of collectors for this one url
     dataCallback: (url, result) => {…},
     // optional ↓
     dataCollectors: [new RequestCollector(), new CookieCollector()],

--- a/cli/crawl-cli.js
+++ b/cli/crawl-cli.js
@@ -16,7 +16,7 @@ const BaseCollector = require('../collectors/BaseCollector');
 const BaseReporter = require('../reporters/BaseReporter');
 
 program
-    .option('-o, --output <path>', '(required) output folder')
+    .option('-o, --output <path>', 'output folder')
     .option('-u, --url <url>', 'single URL')
     .option('-i, --input-list <path>', 'path to list of URLs')
     .option('-d, --data-collectors <list>', `comma separated list of data collectors: ${getCollectorIds().join(', ')} (all by default)`)
@@ -30,7 +30,7 @@ program
     .option('-p, --proxy-config <host>', 'use an optional proxy configuration')
     .option('-r, --region-code <region>', 'optional 2 letter region code. Used for metadata only.')
     .option('-a, --disable-anti-bot', 'disable anti bot detection protections injected to every frame')
-    .option('--config', 'crawl configuration file')
+    .option('--config <path>', 'crawl configuration file')
     .option('--chromium-version <version_number>', 'use custom version of chromium')
     .parse(process.argv);
 

--- a/cli/crawlConfig.js
+++ b/cli/crawlConfig.js
@@ -1,0 +1,129 @@
+const fs = require('fs');
+
+/**
+ * @param {string} url 
+ * @returns {string}
+ */
+function addProtocolIfNeeded(url) {
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+        return url;
+    }
+    return `http://${url}`;
+}
+
+/**
+ * Looks at CLI flags, JSON config etc. to figure out the final crawl config
+ * 
+ * @param {{config?: string, verbose?: boolean, forceOverwrite?: boolean, only3p?: boolean, mobile?: boolean, disableAntiBot?: boolean, output?: string, logPath?: string, crawlers?: string, proxyConfig?: string, regionCode?: string, chromiumVersion?: string, dataCollectors?: string, reporters?: string, url?: string, inputList?: string}} flags 
+ * @returns {CrawlConfig}
+ */
+function figureOut(flags) {
+    /**
+     * @type {CrawlConfig}
+     */
+    let crawlConfig = {};
+
+    if (typeof flags.config === 'string') {
+        crawlConfig = JSON.parse(fs.readFileSync(flags.config).toString());
+    }
+
+    // settings passed via CLI flags override settings passed via config file
+
+    // boolean settings that are false by default
+    if (crawlConfig.verbose === undefined || flags.verbose !== undefined) {
+        crawlConfig.verbose = Boolean(flags.verbose);
+    }
+    if (crawlConfig.forceOverwrite === undefined || flags.forceOverwrite !== undefined) {
+        crawlConfig.forceOverwrite = Boolean(flags.forceOverwrite);
+    }
+    if (crawlConfig.filterOutFirstParty === undefined || flags.only3p !== undefined) {
+        crawlConfig.filterOutFirstParty = Boolean(flags.only3p);
+    }
+    if (crawlConfig.emulateMobile === undefined || flags.mobile !== undefined) {
+        crawlConfig.emulateMobile = Boolean(flags.mobile);
+    }
+    if (crawlConfig.disableAntiBot === undefined || flags.disableAntiBot !== undefined) {
+        crawlConfig.disableAntiBot = Boolean(flags.disableAntiBot);
+    }
+
+    // string/number settings
+    if (flags.output) {
+        crawlConfig.output = flags.output;
+    }
+    if (flags.logPath) {
+        crawlConfig.logPath = flags.logPath;
+    }
+    if (flags.crawlers) {
+        crawlConfig.crawlers = Number(flags.crawlers);
+    }
+    if (flags.proxyConfig) {
+        crawlConfig.proxyConfig = flags.proxyConfig;
+    }
+    if (flags.regionCode) {
+        crawlConfig.regionCode = flags.regionCode;
+    }
+    if (flags.chromiumVersion) {
+        crawlConfig.chromiumVersion = flags.chromiumVersion;
+    }
+
+    // array settings
+    if (flags.dataCollectors) {
+        crawlConfig.dataCollectors = flags.dataCollectors.split(',').map(n => n.trim()).filter(n => n.length > 0);
+    }
+    if (flags.reporters) {
+        crawlConfig.reporters = flags.reporters.split(',').map(n => n.trim()).filter(n => n.length > 0);
+    }
+
+    // ‼️ urls passed via config and via CLI are CONCATENATED
+    /**
+     * @type {Array<string>}
+     */
+    let cliUrls = [];
+
+    if (flags.url) {
+        cliUrls = [flags.url];
+    } else if(flags.inputList) {
+        cliUrls = fs.readFileSync(flags.inputList).toString().split('\n').map(u => u.trim());
+    }
+
+    if (Array.isArray(crawlConfig.urls)) {
+        crawlConfig.urls = crawlConfig.urls.concat(cliUrls);
+    } else {
+        crawlConfig.urls = cliUrls;
+    }
+
+    crawlConfig.urls = crawlConfig.urls.map(item => {
+        if (typeof item === 'string') {
+            return addProtocolIfNeeded(item);
+        } else if (item.url) {
+            item.url = addProtocolIfNeeded(item.url);
+            return item;
+        }
+
+        throw new Error('Unknown url item: ' + item);
+    });
+
+    return crawlConfig;
+}
+
+module.exports = {
+    figureOut
+};
+
+/**
+ * @typedef CrawlConfig
+ * @property {string} output
+ * @property {Array<string|{url:string, dataCollectors:Array<string>}>} urls
+ * @property {Array<string>} dataCollectors
+ * @property {Array<string>} reporters
+ * @property {string} logPath
+ * @property {number} crawlers
+ * @property {string} proxyConfig
+ * @property {string} regionCode
+ * @property {string} chromiumVersion
+ * @property {boolean} filterOutFirstParty
+ * @property {boolean} forceOverwrite
+ * @property {boolean} verbose
+ * @property {boolean} emulateMobile
+ * @property {boolean} disableAntiBot
+ */

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,12 @@
       "integrity": "sha512-C09BK/wXzbW+/JK9zckhe+FeSbg7NmvVjUWwApnw7ksRpUq3ecGLiq2Aw1LlY4Z/VmtdhSaIs7jO5/MWRYMcOA==",
       "dev": true
     },
+    "@types/mockery": {
+      "version": "1.4.30",
+      "resolved": "https://registry.npmjs.org/@types/mockery/-/mockery-1.4.30.tgz",
+      "integrity": "sha512-uv53RrNdhbkV/3VmVCtfImfYCWC3GTTRn3R11Whni3EJ+gb178tkZBVNj2edLY5CMrB749dQi+SJkg87jsN8UQ==",
+      "dev": true
+    },
     "@types/node": {
       "version": "10.14.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.2.tgz",
@@ -821,6 +827,12 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "mockery": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
+      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -24,12 +24,14 @@
   },
   "devDependencies": {
     "@types/async": "^2.4.1",
+    "@types/mockery": "^1.4.30",
     "@types/node": "^10.12.15",
     "@types/progress": "^2.0.3",
     "@types/stack-utils": "^1.0.1",
     "eslint": "^7.2.0",
     "pre-push": "^0.1.1",
-    "typescript": "^4.1.3"
+    "typescript": "^4.1.3",
+    "mockery": "^2.1.0"
   },
   "dependencies": {
     "async": "^2.6.1",

--- a/tests/cli/crawlConfig.test.js
+++ b/tests/cli/crawlConfig.test.js
@@ -1,0 +1,103 @@
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const mockery = require('mockery');
+
+const mockConfigFile = JSON.parse(fs.readFileSync(path.join(__dirname, './sampleConfig.json')).toString());
+
+const mockList = [
+    'one.test',
+    'two.test',
+    'https://three.protocol.test',
+    'http://four.protocol.test'
+];
+
+mockery.enable({
+    warnOnUnregistered: false
+});
+mockery.registerMock('fs', {
+    readFileSync: (/** @type {string} */ filePath) => {
+        if (filePath === 'config.json') {
+            return JSON.stringify(mockConfigFile);
+        } else if (filePath === 'list.txt') {
+            return mockList.join('\n');
+        }
+
+        throw new Error('unknown mock path');
+    }
+});
+
+const crawlConfig = require('../../cli/crawlConfig');
+
+// test if all config options are passed from config and if list is merged with urls
+const result1 = crawlConfig.figureOut({
+    config: 'config.json',
+    inputList: 'list.txt'
+});
+
+assert(result1.output === mockConfigFile.output, "Correct value for 'output'");
+assert(result1.logPath === mockConfigFile.logPath, "Correct value for 'logPath'");
+assert(result1.crawlers === mockConfigFile.crawlers, "Correct value for 'crawlers'");
+assert(result1.verbose === mockConfigFile.verbose, "Correct value for 'verbose'");
+assert(result1.forceOverwrite === mockConfigFile.forceOverwrite, "Correct value for 'forceOverwrite'");
+assert(result1.filterOutFirstParty === mockConfigFile.filterOutFirstParty, "Correct value for 'filterOutFirstParty'");
+assert(result1.emulateMobile === mockConfigFile.emulateMobile, "Correct value for 'emulateMobile'");
+assert(result1.disableAntiBot === mockConfigFile.disableAntiBot, "Correct value for 'disableAntiBot'");
+assert(result1.proxyConfig === mockConfigFile.proxyConfig, "Correct value for 'proxyConfig'");
+assert(result1.regionCode === mockConfigFile.regionCode, "Correct value for 'regionCode'");
+assert(result1.chromiumVersion === mockConfigFile.chromiumVersion, "Correct value for 'chromiumVersion'");
+assert.deepStrictEqual(result1.dataCollectors, mockConfigFile.dataCollectors, "Correct value for 'dataCollectors'");
+assert.deepStrictEqual(result1.reporters, mockConfigFile.reporters, "Correct value for 'reporters'");
+
+assert.deepStrictEqual(result1.urls, [
+    'https://five.test',
+    'http://six.test',
+    'http://one.test',
+    'http://two.test',
+    'https://three.protocol.test',
+    'http://four.protocol.test'
+], "Unexpected value for 'urls'");
+
+// test if CLI flags override config
+
+const flags = {
+    config: 'config.json',
+    output: '/something/else',
+    logPath: '/other/path',
+    crawlers: '666',
+    verbose: false,
+    forceOverwrite: false,
+    only3p: false,
+    mobile: false,
+    disableAntiBot: false,
+    proxyConfig: 'something:else:13',
+    regionCode: 'KA',
+    chromiumVersion: '987654',
+    dataCollectors: 'targets,cookies',
+    reporters: 'html,file',
+    url: 'some.domain.test'
+};
+
+const result2 = crawlConfig.figureOut(flags);
+
+assert(result2.output === flags.output, "Correct value for 'output'");
+assert(result2.logPath === flags.logPath, "Correct value for 'logPath'");
+assert(result2.crawlers === 666, "Correct value for 'crawlers'");
+assert(result2.verbose === flags.verbose, "Correct value for 'verbose'");
+assert(result2.forceOverwrite === flags.forceOverwrite, "Correct value for 'forceOverwrite'");
+assert(result2.filterOutFirstParty === flags.only3p, "Correct value for 'filterOutFirstParty'");
+assert(result2.emulateMobile === flags.mobile, "Correct value for 'emulateMobile'");
+assert(result2.disableAntiBot === flags.disableAntiBot, "Correct value for 'disableAntiBot'");
+assert(result2.proxyConfig === flags.proxyConfig, "Correct value for 'proxyConfig'");
+assert(result2.regionCode === flags.regionCode, "Correct value for 'regionCode'");
+assert(result2.chromiumVersion === flags.chromiumVersion, "Correct value for 'chromiumVersion'");
+assert.deepStrictEqual(result2.dataCollectors, ['targets', 'cookies'], "Correct value for 'dataCollectors'");
+assert.deepStrictEqual(result2.reporters, ['html', 'file'], "Correct value for 'reporters'");
+
+assert.deepStrictEqual(result2.urls, [
+    'https://five.test',
+    'http://six.test',
+    'http://some.domain.test'
+], "Unexpected value for 'urls'");
+
+mockery.disable();

--- a/tests/cli/crawlConfig.test.js
+++ b/tests/cli/crawlConfig.test.js
@@ -29,10 +29,9 @@ mockery.registerMock('fs', {
 
 const crawlConfig = require('../../cli/crawlConfig');
 
-// test if all config options are passed from config and if list is merged with urls
+// test if all config options are passed from config
 const result1 = crawlConfig.figureOut({
-    config: 'config.json',
-    inputList: 'list.txt'
+    config: 'config.json'
 });
 
 assert(result1.output === mockConfigFile.output, "Correct value for 'output'");
@@ -50,18 +49,17 @@ assert.deepStrictEqual(result1.dataCollectors, mockConfigFile.dataCollectors, "C
 assert.deepStrictEqual(result1.reporters, mockConfigFile.reporters, "Correct value for 'reporters'");
 
 assert.deepStrictEqual(result1.urls, [
-    'https://five.test',
-    'http://six.test',
-    'http://one.test',
-    'http://two.test',
-    'https://three.protocol.test',
-    'http://four.protocol.test'
+    "https://five.test",
+    "http://six.test",
+    {"url": "http://seven.test"},
+    {"url": "http://one.test", "dataCollectors": ["targets"]}
 ], "Unexpected value for 'urls'");
 
-// test if CLI flags override config
+// test if CLI flags override config and if list.txt is merged with urls from config.json
 
 const flags = {
     config: 'config.json',
+    inputList: 'list.txt',
     output: '/something/else',
     logPath: '/other/path',
     crawlers: '666',
@@ -74,8 +72,7 @@ const flags = {
     regionCode: 'KA',
     chromiumVersion: '987654',
     dataCollectors: 'targets,cookies',
-    reporters: 'html,file',
-    url: 'some.domain.test'
+    reporters: 'html,file'
 };
 
 const result2 = crawlConfig.figureOut(flags);
@@ -95,9 +92,10 @@ assert.deepStrictEqual(result2.dataCollectors, ['targets', 'cookies'], "Correct 
 assert.deepStrictEqual(result2.reporters, ['html', 'file'], "Correct value for 'reporters'");
 
 assert.deepStrictEqual(result2.urls, [
-    'https://five.test',
-    'http://six.test',
-    'http://some.domain.test'
+    {'url': 'http://one.test', 'dataCollectors': ['targets']},
+    'http://two.test',
+    'https://three.protocol.test',
+    'http://four.protocol.test'
 ], "Unexpected value for 'urls'");
 
 mockery.disable();

--- a/tests/cli/sampleConfig.json
+++ b/tests/cli/sampleConfig.json
@@ -1,0 +1,19 @@
+{
+    "output": "./data/path",
+    "logPath": "./log/path",
+    "crawlers": 12,
+    "verbose": true,
+    "forceOverwrite": true,
+    "filterOutFirstParty": true,
+    "emulateMobile": true,
+    "disableAntiBot": true,
+    "proxyConfig": "bla:bla:123",
+    "regionCode": "PL",
+    "chromiumVersion": "123456",
+    "dataCollectors": ["requests", "apis", "screenshots"],
+    "reporters": ["cli"],
+    "urls": [
+        "https://five.test",
+        "six.test"
+    ]
+}

--- a/tests/cli/sampleConfig.json
+++ b/tests/cli/sampleConfig.json
@@ -14,6 +14,8 @@
     "reporters": ["cli"],
     "urls": [
         "https://five.test",
-        "six.test"
+        "six.test",
+        {"url": "seven.test"},
+        {"url": "one.test", "dataCollectors": ["targets"]}
     ]
 }


### PR DESCRIPTION
Fixes #35 

Sample config file:

```js
{
    "output": "./data/config/out",
    "logPath": "./data/config/log",
    "crawlers": 12,
    "verbose": false,
    "forceOverwrite": true,
    "filterOutFirstParty": false,
    "emulateMobile": false,
    "disableAntiBot": false,
    "dataCollectors": ["requests", "apis", "screenshots"],
    //"proxyConfig": "bla:bla:123",
    //"regionCode": "PL",
    //"chromiumVersion": "123456",
    "reporters": ["cli", "file"],
    "urls": [
        "duck.com",
        "brave.com",
        {"url": "firefox.com"},
        {"url": "microsoftedge.com", "dataCollectors": ["targets", "screenshots"]}
    ]
}
```

and you use it like this:

`npm run crawl -- --config './data/config/config.json'`

CLI flags override config settings in most cases. Only for config/urls + ` --input-list './data/config/list.txt'` we do a merge (as discussed).

This is only beginning for the config, with this in place we will be able to e.g. pass settings to collectors (https://github.com/duckduckgo/tracker-radar-collector/issues/60).