### PR TITLE
Backwards compat for importing older crawls into clickhouse

### DIFF
--- a/reporters/ClickhouseReporter.js
+++ b/reporters/ClickhouseReporter.js
@@ -194,7 +194,7 @@ class ClickhouseReporter extends BaseReporter {
                 this.queue.elements.push([this.crawlId, pageId, data.data.elements.present, data.data.elements.visible]);
             }
             if (data.data.cmps) {
-                const cmpRows = data.data.cmps.map(c => [this.crawlId, pageId, c.name, c.final, c.open, c.started, c.succeeded, c.selfTestFail, c.errors, c.patterns, c.snippets]);
+                const cmpRows = data.data.cmps.map(c => [this.crawlId, pageId, c.name, c.final, c.open, c.started, c.succeeded, c.selfTestFail, c.errors, c.patterns || [], c.snippets || []]);
                 this.queue.cmps = this.queue.cmps.concat(cmpRows);
             }
             if (data.data.apis) {


### PR DESCRIPTION
Fixes clickhouse import of crawls which used an older version of the `CMPCollector`.