### PR TITLE
Expand CH collection

### DIFF
--- a/collectors/APICalls/breakpoints.js
+++ b/collectors/APICalls/breakpoints.js
@@ -182,7 +182,8 @@ const breakpoints = [
     {
         proto: 'NavigatorUAData',
         props: [
-           {name: 'brands'}
+           {name: 'brands'},
+           {name: 'platform'}
         ],
         methods: [
             {name: 'getHighEntropyValues'} // request for high entropy information about browser/OS

--- a/collectors/RequestCollector.js
+++ b/collectors/RequestCollector.js
@@ -7,7 +7,7 @@ const URL = require('url').URL;
 const crypto = require('crypto');
 const {Buffer} = require('buffer');
 
-const DEFAULT_SAVE_HEADERS = ['etag', 'set-cookie', 'cache-control', 'expires', 'pragma', 'p3p', 'timing-allow-origin', 'access-control-allow-origin'];
+const DEFAULT_SAVE_HEADERS = ['etag', 'set-cookie', 'cache-control', 'expires', 'pragma', 'p3p', 'timing-allow-origin', 'access-control-allow-origin', 'accept-ch'];
 
 class RequestCollector extends BaseCollector {
 


### PR DESCRIPTION
Collect accept-ch header by default, we should use it to flag trackers that request high entropy hints.
I also added `navigator.userAgentData.platform` tracking to the mix. Interestingly abuse of NavigatorUAData doesn't look that bad so far - https://slayterdev.github.io/tracker-radar-wiki/apiHistory.html.

![accept-ch](https://user-images.githubusercontent.com/985504/199600835-14f31fcd-3616-48d1-ac93-e28daafbfca7.jpg)