### PR TITLE
Update autoconsent to 4.1.1, drop Node 12

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/collectors/CMPCollector.js
+++ b/collectors/CMPCollector.js
@@ -192,6 +192,7 @@ class CMPCollector extends BaseCollector {
                 autoAction: null, // we request action explicitly later
                 disabledCmps: [],
                 enablePrehide: false,
+                enableCosmeticRules: true,
                 detectRetries: 20,
             };
             await this._cdpClient.send('Runtime.evaluate', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "typescript": "^4.6.4"
       },
       "engines": {
-        "node": ">=12.22.4"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache 2.0",
       "dependencies": {
-        "@duckduckgo/autoconsent": "^2.2.0",
+        "@duckduckgo/autoconsent": "^4.1.1",
         "async": "^2.6.1",
         "chalk": "^2.4.1",
         "clickhouse": "^2.6.0",
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-2.2.0.tgz",
-      "integrity": "sha512-oh5Ce2hV0/BlHB89THIsDU0Uk7kEOCbOziLqS2bP9Yg8hqwD5yslUUGt/X/w+HlwU3BK83q9GwRGJtLnjJarcw=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-4.1.1.tgz",
+      "integrity": "sha512-lyP3wFpPCOGV3McI3LcKq1OMdfD8alAlX8aNmIpTQ8xoa2xaEzRAf3CaajAlK5+sOdPw3an3spif1RIIxkfp9Q=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
@@ -3187,9 +3187,9 @@
       }
     },
     "@duckduckgo/autoconsent": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-2.2.0.tgz",
-      "integrity": "sha512-oh5Ce2hV0/BlHB89THIsDU0Uk7kEOCbOziLqS2bP9Yg8hqwD5yslUUGt/X/w+HlwU3BK83q9GwRGJtLnjJarcw=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-4.1.1.tgz",
+      "integrity": "sha512-lyP3wFpPCOGV3McI3LcKq1OMdfD8alAlX8aNmIpTQ8xoa2xaEzRAf3CaajAlK5+sOdPw3an3spif1RIIxkfp9Q=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test"
   ],
   "engines": {
-    "node": ">=12.22.4"
+    "node": ">=14.0.0"
   },
   "devDependencies": {
     "@types/async": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "@duckduckgo/autoconsent": "^2.2.0",
+    "@duckduckgo/autoconsent": "^4.1.1",
     "async": "^2.6.1",
     "chalk": "^2.4.1",
     "clickhouse": "^2.6.0",

--- a/tests/collectors/CMPCollector.mocha.js
+++ b/tests/collectors/CMPCollector.mocha.js
@@ -88,6 +88,7 @@ describe('CMPCollector', () => {
                         autoAction: null,
                         disabledCmps: [],
                         enablePrehide: false,
+                        enableCosmeticRules: true,
                         detectRetries: 20,
                     })} })`,
                     contextId: 1111,
@@ -187,6 +188,7 @@ describe('CMPCollector', () => {
                     type: 'autoconsentDone',
                     cmp: 'some cmp',
                     url: 'some url',
+                    isCosmetic: false,
                 };
                 collector.selfTestFrame = null;
                 commands.splice(0, commands.length);
@@ -202,6 +204,7 @@ describe('CMPCollector', () => {
                     type: 'autoconsentDone',
                     cmp: 'some cmp',
                     url: 'some url',
+                    isCosmetic: false,
                 };
                 collector.selfTestFrame = 1337;
                 commands.splice(0, commands.length);


### PR DESCRIPTION
**Breaking change**: Node 12 is not supported anymore because puppeteer dropped support last year