### PR TITLE
Fix flaky integration tests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/crawler.js
+++ b/crawler.js
@@ -77,7 +77,7 @@ class Crawler {
         this.targets.set(targetInfo.id, targetInfo);
         try {
             await this._onTargetAttached(session, targetInfo);
-            this.log(`${targetInfo.url} (${targetInfo.url}) context initiated in ${timer.getElapsedTime()}s`);
+            this.log(`${targetInfo.url} (${targetInfo.url}) target attached in ${timer.getElapsedTime()}s`);
         } catch (e) {
             this.log(chalk.yellow(`Could not attach to ${targetInfo.type} ${targetInfo.url}: ${e.message}`));
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "typescript": "^5.7.3"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1563,18 +1563,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "git@github.com:duckduckgo/tracker-radar-crawler.git"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "devDependencies": {
     "@types/async": "^3.2.24",

--- a/tests/integration/apiCollection.test.js
+++ b/tests/integration/apiCollection.test.js
@@ -8,8 +8,11 @@ async function main() {
 
     let apiData;
     try {
-        apiData = await crawler(new URL('https://privacy-test-pages.site/privacy-protections/fingerprinting/?run'), {
-            collectors: [new APICallCollector()]
+        apiData = await crawler(new URL('https://privacy-test-pages.site/privacy-protections/fingerprinting/'), {
+            collectors: [new APICallCollector()],
+            // @ts-expect-error we know that #start is a button
+            // eslint-disable-next-line no-undef
+            runInEveryFrame: () => setTimeout(() => document.querySelector("#start")?.click(), 500),
         });
     } catch (e) {
         assert(false, `Page load failed - ${e}`);

--- a/tests/integration/apiCollection.test.js
+++ b/tests/integration/apiCollection.test.js
@@ -10,6 +10,9 @@ async function main() {
     try {
         apiData = await crawler(new URL('https://privacy-test-pages.site/privacy-protections/fingerprinting/'), {
             collectors: [new APICallCollector()],
+
+            // There's a bug in APICallCollector: it misses calls made before it's fully initialized. This delay is a workaround for it.
+            // see https://app.asana.com/1/137249556945/project/1118485203673454/task/1210055009227658
             // @ts-expect-error we know that #start is a button
             // eslint-disable-next-line no-undef
             runInEveryFrame: () => setTimeout(() => document.querySelector("#start")?.click(), 500),


### PR DESCRIPTION
This PR
- drops support of Node 16 (new Puppeteer doesn't support it anymore) and adds Node 22 to CI checks
- adds a workaround for a race condition in the APICallCollector

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210055009227653