### PR TITLE
Add simple selector escaping

### DIFF
--- a/collectors/CookiePopups/scrapeScript.js
+++ b/collectors/CookiePopups/scrapeScript.js
@@ -98,6 +98,15 @@ function getButtons(el) {
 }
 
 /**
+ * Naive selector escaping. Use with caution.
+ * @param {string} selector
+ * @returns {string}
+ */
+function insecureEscapeSelectorPart(selector) {
+    return selector.replace(/[.*+?^${}()|[\]\\"]/g, '\\$&');
+}
+
+/**
  * Get the selector for an element
  * @param {HTMLElement} el - The element to get the selector for
  * @param {{ order?: boolean, ids?: boolean, dataAttributes?: boolean, classes?: boolean, absoluteOrder?: boolean }} specificity - details to add to the selector
@@ -134,7 +143,7 @@ function getSelector(el, specificity) {
 
         if (specificity.ids) {
             if (element.id) {
-                localSelector += `#${element.id}`;
+                localSelector += `#${insecureEscapeSelectorPart(element.id)}`;
             } else if (!element.hasAttribute('id')) { // do not add it for id attribute without a value
                 localSelector += `:not([id])`;
             }
@@ -143,7 +152,7 @@ function getSelector(el, specificity) {
         if (specificity.dataAttributes) {
             const dataAttributes = Array.from(element.attributes).filter(a => a.name.startsWith('data-'));
             dataAttributes.forEach(a => {
-                const escapedValue = a.value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+                const escapedValue = insecureEscapeSelectorPart(a.value);
                 localSelector += `[${a.name}="${escapedValue}"]`;
             });
         }
@@ -151,7 +160,7 @@ function getSelector(el, specificity) {
         if (specificity.classes) {
             const classes = Array.from(element.classList);
             if (classes.length > 0) {
-                localSelector += `.${classes.join('.')}`;
+                localSelector += `.${classes.map(c => insecureEscapeSelectorPart(c)).join('.')}`;
             }
         }
 


### PR DESCRIPTION
[Some sites](https://github.com/duckduckgo/autoconsent/pull/802/commits/c2280e50b7d5ed013d64ef1463f24745498605ce) use IDs with special characters. This change guards against some simple cases.