### PR TITLE
Add additional context to autoconsent manifest output

### DIFF
--- a/post-processing/generate-autoconsent-rules/main.js
+++ b/post-processing/generate-autoconsent-rules/main.js
@@ -259,10 +259,21 @@ async function processFiles(globalParams, existingRules) {
 
         totalSitesWithPopups++;
 
+        const matchedRules = collectorResult.cmps.map(cmp => cmp.name.trim()).filter(name => name !== '');
+        const llmConfirmedPopups = collectorResult.scrapedFrames.flatMap(frame => frame.potentialPopups).filter(popup => popup.llmMatch);
+
         if (hasKnownCmp(collectorResult.cmps)) {
             totalSitesWithKnownCmps++;
+            autoconsentManifest.set(fileName, {
+                siteUrl: jsonData.finalUrl,
+                matchedRules,
+                llmConfirmedPopups,
+                newlyCreatedRules: [],
+                updatedRules: [],
+                reviewNotes: [],
+            });
         } else {
-            const llmConfirmedPopups = collectorResult.scrapedFrames.flatMap(frame => frame.potentialPopups).filter(popup => popup.llmMatch);
+            
             /** @type {import('./types').AutoconsentManifestFileData[]} */
             let newRuleFiles = [];
             /** @type {import('./types').AutoconsentManifestFileData[]} */
@@ -281,14 +292,14 @@ async function processFiles(globalParams, existingRules) {
                 ({ newRuleFiles, updatedRuleFiles, keptCount, reviewNotes, updatedExistingRules: existingRulesAfter } = result);
             }
 
-            if (newRuleFiles.length > 0 || updatedRuleFiles.length > 0 || reviewNotes.length > 0) {
-                autoconsentManifest.set(fileName, {
-                    siteUrl: jsonData.finalUrl,
-                    newlyCreatedRules: newRuleFiles,
-                    updatedRules: updatedRuleFiles,
-                    reviewNotes
-                });
-            }
+            autoconsentManifest.set(fileName, {
+                siteUrl: jsonData.finalUrl,
+                matchedRules,
+                llmConfirmedPopups,
+                newlyCreatedRules: newRuleFiles,
+                updatedRules: updatedRuleFiles,
+                reviewNotes
+            });
 
             if (newRuleFiles.length > 0 || keptCount > 0 || updatedRuleFiles.length > 0) {
                 if (newRuleFiles.length > 0) {

--- a/post-processing/generate-autoconsent-rules/main.js
+++ b/post-processing/generate-autoconsent-rules/main.js
@@ -261,6 +261,7 @@ async function processFiles(globalParams, existingRules) {
 
         const matchedRules = collectorResult.cmps.map(cmp => cmp.name.trim()).filter(name => name !== '');
         const llmConfirmedPopups = collectorResult.scrapedFrames.flatMap(frame => frame.potentialPopups).filter(popup => popup.llmMatch);
+        const screenshot = jsonData.data.screenshots;
 
         if (hasKnownCmp(collectorResult.cmps)) {
             totalSitesWithKnownCmps++;
@@ -268,6 +269,7 @@ async function processFiles(globalParams, existingRules) {
                 siteUrl: jsonData.finalUrl,
                 matchedRules,
                 llmConfirmedPopups,
+                screenshot,
                 newlyCreatedRules: [],
                 updatedRules: [],
                 reviewNotes: [],
@@ -296,6 +298,7 @@ async function processFiles(globalParams, existingRules) {
                 siteUrl: jsonData.finalUrl,
                 matchedRules,
                 llmConfirmedPopups,
+                screenshot,
                 newlyCreatedRules: newRuleFiles,
                 updatedRules: updatedRuleFiles,
                 reviewNotes

--- a/post-processing/generate-autoconsent-rules/types.js
+++ b/post-processing/generate-autoconsent-rules/types.js
@@ -38,6 +38,8 @@
 /**
  * @typedef {{
  *  siteUrl: string;
+ *  matchedRules: string[];
+ *  llmConfirmedPopups: PopupData[];
  *  newlyCreatedRules: AutoconsentManifestFileData[];
  *  updatedRules: AutoconsentManifestFileData[];
  *  reviewNotes: ReviewNote[];

--- a/post-processing/generate-autoconsent-rules/types.js
+++ b/post-processing/generate-autoconsent-rules/types.js
@@ -2,6 +2,7 @@
  * @typedef {{
  *  data: {
  *      cookiepopups: import('../../collectors/CookiePopupsCollector').CookiePopupsCollectorResult;
+ *      screenshots?: string;
  *  };
  *  finalUrl: string;
  * }} CrawlData
@@ -40,6 +41,7 @@
  *  siteUrl: string;
  *  matchedRules: string[];
  *  llmConfirmedPopups: PopupData[];
+ *  screenshot: string;
  *  newlyCreatedRules: AutoconsentManifestFileData[];
  *  updatedRules: AutoconsentManifestFileData[];
  *  reviewNotes: ReviewNote[];


### PR DESCRIPTION
This is for analysis of the crawl results in downstream jobs.