### PR TITLE
CPM updates

### DIFF
--- a/collectors/CookiePopupsCollector.js
+++ b/collectors/CookiePopupsCollector.js
@@ -4,8 +4,9 @@ const ContentScriptCollector = require('./ContentScriptCollector');
 const { createTimer } = require('../helpers/timer');
 const { wait, TimeoutError } = require('../helpers/wait');
 const createDeferred = require('../helpers/deferred');
-const rules = require('@duckduckgo/autoconsent/rules/rules.json');
-const stringifiedRules = JSON.stringify(rules);
+const { filterCompactRules } = require('@duckduckgo/autoconsent');
+const compactRules = require('@duckduckgo/autoconsent/rules/compact-rules.json');
+const { consentomatic } = require('@duckduckgo/autoconsent/rules/consentomatic.json');
 
 // @ts-ignore
 const baseContentScript = fs.readFileSync(
@@ -62,6 +63,22 @@ class CookiePopupsCollector extends ContentScriptCollector {
 
         /** @type {import('../helpers/deferred').Deferred<ScrapeScriptResult[]>} */
         this.scrapeJobDeferred = createDeferred();
+
+        /** @type {Set<string>} */
+        this.mainFrameIds = new Set();
+        /** @type {Map<string, { frameId: string, isMainFrame: boolean }>} */
+        this.contextFrameInfo = new Map();
+    }
+
+    /**
+     * @param {import('puppeteer-core').CDPSession} session
+     * @param {import('devtools-protocol/types/protocol').Protocol.Target.TargetInfo} targetInfo
+     */
+    addTarget(session, targetInfo) {
+        if (targetInfo.type === 'page') {
+            this.mainFrameIds.add(targetInfo.targetId);
+        }
+        super.addTarget(session, targetInfo);
     }
 
     /**
@@ -96,6 +113,14 @@ class CookiePopupsCollector extends ContentScriptCollector {
      * @param {import('devtools-protocol/types/protocol').Protocol.Runtime.ExecutionContextDescription} context
      */
     async onIsolatedWorldCreated(session, context) {
+        const frameId = context.auxData?.frameId;
+        if (frameId) {
+            this.contextFrameInfo.set(context.uniqueId, {
+                frameId,
+                isMainFrame: this.mainFrameIds.has(frameId),
+            });
+        }
+
         const bindingName = `${BINDING_NAME_PREFIX}${context.uniqueId.replace(/\W/g, '_')}`;
         session.on('Runtime.bindingCalled', async ({ name, payload }) => {
             if (name === bindingName) {
@@ -160,8 +185,25 @@ class CookiePopupsCollector extends ContentScriptCollector {
                     detectRetries: 20,
                     isMainWorld: false,
                 };
+                const frameInfo = this.contextFrameInfo.get(executionContextUniqueId);
+                const isMainFrame = frameInfo?.isMainFrame ?? true;
+                const frameUrl = msg.url || '';
+                /** @type {import('../node_modules/@duckduckgo/autoconsent/lib/types').RuleBundle} */
+                const filteredRules = {
+                    autoconsent: [],
+                    consentomatic,
+                };
+                if (compactRules.index) {
+                    filteredRules.compact = filterCompactRules(
+                        /** @type {import('../node_modules/@duckduckgo/autoconsent/lib/encoding').IndexedCMPRuleset} */
+                        (compactRules),
+                        { url: frameUrl, mainFrame: isMainFrame },
+                    );
+                } else {
+                    filteredRules.compact = compactRules;
+                }
                 await this.cdpSessions.get(executionContextUniqueId)?.send('Runtime.evaluate', {
-                    expression: `autoconsentReceiveMessage({ type: "initResp", config: ${JSON.stringify(autoconsentConfig)}, rules: ${stringifiedRules} })`,
+                    expression: `autoconsentReceiveMessage({ type: "initResp", config: ${JSON.stringify(autoconsentConfig)}, rules: ${JSON.stringify(filteredRules)} })`,
                     uniqueContextId: executionContextUniqueId,
                 });
                 break;

--- a/collectors/CookiePopupsCollector.js
+++ b/collectors/CookiePopupsCollector.js
@@ -156,6 +156,7 @@ class CookiePopupsCollector extends ContentScriptCollector {
                     enableCosmeticRules: true,
                     enableFilterList: false,
                     enableHeuristicDetection: true,
+                    enableHeuristicAction: true,
                     detectRetries: 20,
                     isMainWorld: false,
                 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache 2.0",
       "dependencies": {
         "@clickhouse/client": "^1.11.1",
-        "@duckduckgo/autoconsent": "^14.56.0",
+        "@duckduckgo/autoconsent": "^14.67.0",
         "@types/commander": "^2.12.0",
         "async": "^3.2.6",
         "chalk": "^4.1.2",
@@ -83,9 +83,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.62.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.62.0.tgz",
-      "integrity": "sha512-SryapxIiOSPAr1D/SllmQdwrGOgNwwUzpQ8ki3Psx2vOxHou6yCDEik2ORIL1VOc1dDsINjJ1hdQm/c5CmVw1w==",
+      "version": "14.67.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.67.0.tgz",
+      "integrity": "sha512-mZMpDdn7IrgtJ3JFWbxU8krkZAS11PMqASmBqEpgWvEhbcL3leB2dzh1kA/KNyrmUv/iHrIVVLuZt5HlgyfsWQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache 2.0",
       "dependencies": {
         "@clickhouse/client": "^1.11.1",
-        "@duckduckgo/autoconsent": "^14.34.0",
+        "@duckduckgo/autoconsent": "^14.56.0",
         "@types/commander": "^2.12.0",
         "async": "^3.2.6",
         "chalk": "^4.1.2",
@@ -83,9 +83,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.34.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.34.0.tgz",
-      "integrity": "sha512-UYM0Bp209TDGBheOzSJY4UGEXrx3+rMIWg/uCT9LnoYbhqvxWIR3XxsKMcUmnc+vdEnP24gm8XQCDMMTayRk8w==",
+      "version": "14.56.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.56.0.tgz",
+      "integrity": "sha512-0gImNtILoEb4LtQkCXJ7pjwqV3lY4IG7sm9y+cbB218MqKKoMJ/zht9UEI0bJ2J2IZZ0GEcLQE9TsQ3AISFZ5Q==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,9 +83,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.56.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.56.0.tgz",
-      "integrity": "sha512-0gImNtILoEb4LtQkCXJ7pjwqV3lY4IG7sm9y+cbB218MqKKoMJ/zht9UEI0bJ2J2IZZ0GEcLQE9TsQ3AISFZ5Q==",
+      "version": "14.62.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.62.0.tgz",
+      "integrity": "sha512-SryapxIiOSPAr1D/SllmQdwrGOgNwwUzpQ8ki3Psx2vOxHou6yCDEik2ORIL1VOc1dDsINjJ1hdQm/c5CmVw1w==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@clickhouse/client": "^1.11.1",
-    "@duckduckgo/autoconsent": "^14.34.0",
+    "@duckduckgo/autoconsent": "^14.56.0",
     "@types/commander": "^2.12.0",
     "async": "^3.2.6",
     "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@clickhouse/client": "^1.11.1",
-    "@duckduckgo/autoconsent": "^14.56.0",
+    "@duckduckgo/autoconsent": "^14.67.0",
     "@types/commander": "^2.12.0",
     "async": "^3.2.6",
     "chalk": "^4.1.2",

--- a/tests/collectors/CookiePopupsCollector.mocha.js
+++ b/tests/collectors/CookiePopupsCollector.mocha.js
@@ -1,6 +1,7 @@
 const CookiePopupsCollector = require('../../collectors/CookiePopupsCollector');
-const rules = require('@duckduckgo/autoconsent/rules/rules.json');
-const stringifiedRules = JSON.stringify(rules);
+const { filterCompactRules } = require('@duckduckgo/autoconsent');
+const compactRules = require('@duckduckgo/autoconsent/rules/compact-rules.json');
+const { consentomatic } = require('@duckduckgo/autoconsent/rules/consentomatic.json');
 const assert = require('assert');
 const sinon = require('sinon');
 
@@ -68,7 +69,7 @@ describe('CookiePopupsCollector', () => {
             },
         });
         // @ts-expect-error not a real CDP client
-        await collector.addTarget(fakeCDPClient, { type: 'page', url: 'https://example.com' });
+        await collector.addTarget(fakeCDPClient, { type: 'page', url: 'https://example.com', targetId: 'someframeid' });
         // @ts-expect-error passing mock objects
         collector.cdpSessions.set('1111', fakeCDPClient);
         // @ts-expect-error passing mock objects
@@ -77,31 +78,77 @@ describe('CookiePopupsCollector', () => {
 
     describe('handleMessage', () => {
         describe('init ', () => {
-            it('should respond with initResp', async () => {
+            it('should respond with initResp with filtered compact rules', async () => {
                 /**
                  * @type {ContentScriptMessage}
                  */
                 const msg = {
                     type: 'init',
-                    url: 'some-url',
+                    url: 'https://example.com/',
                 };
+                collector.contextFrameInfo.set('1111', { frameId: 'someframeid', isMainFrame: true });
                 commands.splice(0, commands.length);
                 await collector.handleMessage(msg, '1111');
                 assert.strictEqual(commands.length, 1);
+                const expectedConfig = {
+                    enabled: true,
+                    autoAction: null,
+                    disabledCmps: [],
+                    enablePrehide: false,
+                    enableCosmeticRules: true,
+                    enableFilterList: false,
+                    enableHeuristicDetection: true,
+                    enableHeuristicAction: true,
+                    detectRetries: 20,
+                    isMainWorld: false,
+                };
+                const expectedRules = {
+                    autoconsent: [],
+                    consentomatic,
+                    compact: filterCompactRules(compactRules, { url: 'https://example.com/', mainFrame: true }),
+                };
                 assert.deepStrictEqual(commands[0], [
                     'Runtime.evaluate',
                     {
-                        expression: `autoconsentReceiveMessage({ type: "initResp", config: ${JSON.stringify({
-                            enabled: true,
-                            autoAction: null,
-                            disabledCmps: [],
-                            enablePrehide: false,
-                            enableCosmeticRules: true,
-                            enableFilterList: false,
-                            enableHeuristicDetection: true,
-                            detectRetries: 20,
-                            isMainWorld: false,
-                        })}, rules: ${stringifiedRules} })`,
+                        expression: `autoconsentReceiveMessage({ type: "initResp", config: ${JSON.stringify(expectedConfig)}, rules: ${JSON.stringify(expectedRules)} })`,
+                        uniqueContextId: '1111',
+                    },
+                ]);
+            });
+
+            it('should filter rules for sub-frames', async () => {
+                /**
+                 * @type {ContentScriptMessage}
+                 */
+                const msg = {
+                    type: 'init',
+                    url: 'https://consent.example.com/iframe',
+                };
+                collector.contextFrameInfo.set('1111', { frameId: 'subframeid', isMainFrame: false });
+                commands.splice(0, commands.length);
+                await collector.handleMessage(msg, '1111');
+                assert.strictEqual(commands.length, 1);
+                const expectedConfig = {
+                    enabled: true,
+                    autoAction: null,
+                    disabledCmps: [],
+                    enablePrehide: false,
+                    enableCosmeticRules: true,
+                    enableFilterList: false,
+                    enableHeuristicDetection: true,
+                    enableHeuristicAction: true,
+                    detectRetries: 20,
+                    isMainWorld: false,
+                };
+                const expectedRules = {
+                    autoconsent: [],
+                    consentomatic,
+                    compact: filterCompactRules(compactRules, { url: 'https://consent.example.com/iframe', mainFrame: false }),
+                };
+                assert.deepStrictEqual(commands[0], [
+                    'Runtime.evaluate',
+                    {
+                        expression: `autoconsentReceiveMessage({ type: "initResp", config: ${JSON.stringify(expectedConfig)}, rules: ${JSON.stringify(expectedRules)} })`,
                         uniqueContextId: '1111',
                     },
                 ]);


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1201844467387842/task/1213531596089185?focus=true


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Autoconsent rules are selected and sent to frames (main vs subframe) and bumps the Autoconsent dependency, which can alter CMP detection/interaction behavior across crawls.
> 
> **Overview**
> Switches `CookiePopupsCollector` from sending the full `rules.json` bundle to building a per-frame rule bundle using `compact-rules.json` + `consentomatic.json`, filtered via `filterCompactRules` using the frame URL and whether the context is a main frame.
> 
> Adds frame tracking (`mainFrameIds`/`contextFrameInfo`) and enables `enableHeuristicAction` in the init config; tests are updated to assert rule filtering for main-frame vs sub-frame contexts, and `@duckduckgo/autoconsent` is bumped to `^14.67.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df86438faaf422666a4510e2f266132614b0899a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->