### PR TITLE
Add autoconsent CDP profile metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # DuckDuckGo Tracker Radar Collector
+
 🕸 Modular, multithreaded, [puppeteer](https://github.com/GoogleChrome/puppeteer)-based crawler used to generate third party request data for the [Tracker Radar](https://github.com/duckduckgo/tracker-radar).
 
 ## How do I use it?
@@ -128,6 +129,7 @@ Additionally, each collector can override following methods:
 There are couple of built-in collectors in the `collectors/` folder. `CookieCollector` is the simplest one and can be used as a template.
 
 Each new collector has to be added in two places to be discoverable:
+
 - `crawlerConductor.js` - so that `crawlerConductor` knows about it (and it can be used in the CLI tool)
 - `main.js` - so that the new collector can be imported by other projects
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Available options:
 - `--selenium-hub <url>` - If provided, browsers will be requested from selenium hub instead of spawning local processes (e.g. `--selenium-hub http://my-selenium-hub-host:4444`).
 - `--config <path>` - path to a config file that allows to set all the above settings (and more). Note that CLI flags have a higher priority than settings passed via config. You can find a sample config file in `tests/cli/sampleConfig.json`.
 - `--autoconsent-action <action>` - automatic autoconsent action (requires the `cookiepopups` collector). Possible values: optIn, optOut
+- `--autoconsent-profile` - collect a CDP CPU profile summary for the autoconsent script (requires the `cookiepopups` collector)
 
 ### Use it as a module
 

--- a/cli/crawl-cli.js
+++ b/cli/crawl-cli.js
@@ -33,6 +33,10 @@ program
         '--autoconsent-action <action>',
         'dismiss cookie popups. Possible values: optOut, optIn. Works only when cookiepopups collector is enabled.',
     )
+    .option(
+        '--autoconsent-profile',
+        'collect a CDP CPU profile summary for the autoconsent script. Works only when cookiepopups collector is enabled.',
+    )
     .option('--chromium-version <version_number>', 'use custom version of chromium')
     .option('--selenium-hub <url>', 'selenium hub endpoint to request browsers from')
     .parse(process.argv);
@@ -230,7 +234,8 @@ async function run({
 
 const config = crawlConfig.figureOut(program.opts());
 const collectorFlags = {
-    autoconsentAction: program.opts().autoconsentAction,
+    autoconsentAction: config.autoconsentAction,
+    autoconsentProfile: config.autoconsentProfile,
     enableAsyncStacktraces: true, // this flag is disabled during retries
     shortTimeouts: false,
 };

--- a/cli/crawlConfig.js
+++ b/cli/crawlConfig.js
@@ -14,7 +14,7 @@ function addProtocolIfNeeded(url) {
 /**
  * Looks at CLI flags, JSON config etc. to figure out the final crawl config
  *
- * @param {{config?: string, verbose?: boolean, forceOverwrite?: boolean, only3p?: boolean, mobile?: boolean, disableAntiBot?: boolean, output?: string, logPath?: string, crawlers?: string, proxyConfig?: string, regionCode?: string, chromiumVersion?: string, seleniumHub?: string, dataCollectors?: string, reporters?: string, url?: string, inputList?: string}} flags
+ * @param {{config?: string, verbose?: boolean, forceOverwrite?: boolean, only3p?: boolean, mobile?: boolean, disableAntiBot?: boolean, autoconsentProfile?: boolean, output?: string, logPath?: string, crawlers?: string, proxyConfig?: string, regionCode?: string, chromiumVersion?: string, seleniumHub?: string, autoconsentAction?: string, dataCollectors?: string, reporters?: string, url?: string, inputList?: string}} flags
  * @returns {CrawlConfig}
  */
 function figureOut(flags) {
@@ -45,6 +45,9 @@ function figureOut(flags) {
     if (crawlConfig.disableAntiBot === undefined || flags.disableAntiBot !== undefined) {
         crawlConfig.disableAntiBot = Boolean(flags.disableAntiBot);
     }
+    if (crawlConfig.autoconsentProfile === undefined || flags.autoconsentProfile !== undefined) {
+        crawlConfig.autoconsentProfile = Boolean(flags.autoconsentProfile);
+    }
 
     // string/number settings
     if (flags.output) {
@@ -67,6 +70,9 @@ function figureOut(flags) {
     }
     if (flags.seleniumHub) {
         crawlConfig.seleniumHub = flags.seleniumHub;
+    }
+    if (flags.autoconsentAction) {
+        crawlConfig.autoconsentAction = flags.autoconsentAction;
     }
 
     // array settings
@@ -151,4 +157,6 @@ module.exports = {
  * @property {number} maxLoadTimeMs
  * @property {number} extraExecutionTimeMs
  * @property {string} seleniumHub
+ * @property {string} autoconsentAction
+ * @property {boolean} autoconsentProfile
  */

--- a/collectors/BaseCollector.js
+++ b/collectors/BaseCollector.js
@@ -58,6 +58,7 @@ class BaseCollector {
  * @typedef CollectorFlags
  * @property {boolean=} enableAsyncStacktraces
  * @property {import('@duckduckgo/autoconsent/lib/types').AutoAction=} autoconsentAction
+ * @property {boolean=} autoconsentProfile
  * @property {boolean=} shortTimeouts  // used to speed up unit tests
  */
 

--- a/collectors/CookiePopupsCollector.js
+++ b/collectors/CookiePopupsCollector.js
@@ -15,10 +15,13 @@ const baseContentScript = fs.readFileSync(
 );
 
 const BINDING_NAME_PREFIX = 'cdpAutoconsentSendMessage_';
+const AUTOCONSENT_SOURCE_URL = 'duckduckgo-autoconsent.js';
 const SCRAPE_TIMEOUT = 20000;
 const OPTOUT_TIMEOUT = 30000;
 const DETECT_TIMEOUT = 5000;
 const FOUND_TIMEOUT = 5000;
+const PROFILER_SAMPLING_INTERVAL_US = 1000;
+const PROFILE_TOP_FUNCTIONS_LIMIT = 10;
 
 /**
  * @param {string} bindingName
@@ -30,11 +33,217 @@ function getAutoconsentContentScript(bindingName) {
 window.autoconsentSendMessage = (msg) => {
     window.${bindingName}(JSON.stringify(msg));
 };
-` + baseContentScript
+` +
+        baseContentScript +
+        `\n//# sourceURL=${AUTOCONSENT_SOURCE_URL}`
     );
 }
 
 const cookiePopupScrapeScript = fs.readFileSync(require.resolve('./CookiePopups/scrapeScript.js'), 'utf8');
+
+/**
+ * @param {number} value
+ * @returns {number}
+ */
+function roundMs(value) {
+    return Number(value.toFixed(3));
+}
+
+/**
+ * @param {import('devtools-protocol/types/protocol').Protocol.Profiler.ProfileNode} node
+ * @returns {string}
+ */
+function getProfileNodeKey(node) {
+    const callFrame = node.callFrame;
+    return [
+        callFrame.functionName || '(anonymous)',
+        callFrame.url || '',
+        callFrame.lineNumber,
+        callFrame.columnNumber,
+    ].join(':');
+}
+
+/**
+ * @param {import('devtools-protocol/types/protocol').Protocol.Profiler.ProfileNode} node
+ * @returns {boolean}
+ */
+function isAutoconsentProfileNode(node) {
+    const url = node.callFrame.url || '';
+    return url === AUTOCONSENT_SOURCE_URL || url.endsWith(`/${AUTOCONSENT_SOURCE_URL}`);
+}
+
+/**
+ * @param {import('devtools-protocol/types/protocol').Protocol.Profiler.Profile} profile
+ * @returns {AutoconsentProfileSummary}
+ */
+function summarizeProfile(profile) {
+    /** @type {Map<number, import('devtools-protocol/types/protocol').Protocol.Profiler.ProfileNode>} */
+    const nodeById = new Map();
+    /** @type {Map<number, number>} */
+    const parentById = new Map();
+    /** @type {Map<string, AutoconsentProfileFunctionSummary>} */
+    const functionsByKey = new Map();
+
+    for (const node of profile.nodes || []) {
+        nodeById.set(node.id, node);
+        for (const childId of node.children || []) {
+            parentById.set(childId, node.id);
+        }
+    }
+
+    const samples = profile.samples || [];
+    const timeDeltas = profile.timeDeltas || [];
+    const fallbackDeltaUs =
+        !timeDeltas.length && profile.endTime && profile.startTime && samples.length
+            ? (profile.endTime - profile.startTime) / samples.length
+            : 0;
+
+    let totalProfiledTimeMs = 0;
+    let autoconsentScriptTimeMs = 0;
+    let autoconsentSelfTimeMs = 0;
+    let autoconsentSampleCount = 0;
+
+    for (const [index, nodeId] of samples.entries()) {
+        const deltaMs = (timeDeltas[index] || fallbackDeltaUs) / 1000;
+        totalProfiledTimeMs += deltaMs;
+
+        /** @type {import('devtools-protocol/types/protocol').Protocol.Profiler.ProfileNode[]} */
+        const stack = [];
+        let currentNode = nodeById.get(nodeId);
+        while (currentNode) {
+            stack.push(currentNode);
+            const parentId = parentById.get(currentNode.id);
+            currentNode = parentId ? nodeById.get(parentId) : null;
+        }
+
+        const autoconsentNodes = stack.filter(isAutoconsentProfileNode);
+        if (autoconsentNodes.length === 0) {
+            continue;
+        }
+
+        autoconsentScriptTimeMs += deltaMs;
+        autoconsentSampleCount++;
+
+        const leafNode = nodeById.get(nodeId);
+        if (leafNode && isAutoconsentProfileNode(leafNode)) {
+            const key = getProfileNodeKey(leafNode);
+            if (!functionsByKey.has(key)) {
+                functionsByKey.set(key, {
+                    functionName: leafNode.callFrame.functionName || '(anonymous)',
+                    url: leafNode.callFrame.url || '',
+                    lineNumber: leafNode.callFrame.lineNumber,
+                    columnNumber: leafNode.callFrame.columnNumber,
+                    selfTimeMs: 0,
+                    totalTimeMs: 0,
+                    hitCount: 0,
+                });
+            }
+            const functionSummary = functionsByKey.get(key);
+            functionSummary.selfTimeMs += deltaMs;
+            functionSummary.hitCount++;
+            autoconsentSelfTimeMs += deltaMs;
+        }
+
+        for (const node of autoconsentNodes) {
+            const key = getProfileNodeKey(node);
+            if (!functionsByKey.has(key)) {
+                functionsByKey.set(key, {
+                    functionName: node.callFrame.functionName || '(anonymous)',
+                    url: node.callFrame.url || '',
+                    lineNumber: node.callFrame.lineNumber,
+                    columnNumber: node.callFrame.columnNumber,
+                    selfTimeMs: 0,
+                    totalTimeMs: 0,
+                    hitCount: 0,
+                });
+            }
+            functionsByKey.get(key).totalTimeMs += deltaMs;
+        }
+    }
+
+    const topFunctions = Array.from(functionsByKey.values())
+        .map((functionSummary) => ({
+            ...functionSummary,
+            selfTimeMs: roundMs(functionSummary.selfTimeMs),
+            totalTimeMs: roundMs(functionSummary.totalTimeMs),
+        }))
+        .sort((a, b) => b.selfTimeMs - a.selfTimeMs || b.totalTimeMs - a.totalTimeMs)
+        .slice(0, PROFILE_TOP_FUNCTIONS_LIMIT);
+
+    return {
+        totalProfiledTimeMs: roundMs(totalProfiledTimeMs),
+        autoconsentScriptTimeMs: roundMs(autoconsentScriptTimeMs),
+        autoconsentSelfTimeMs: roundMs(autoconsentSelfTimeMs),
+        totalSampleCount: samples.length,
+        autoconsentSampleCount,
+        topFunctions,
+    };
+}
+
+/**
+ * @param {AutoconsentProfileSummary[]} summaries
+ * @param {string[]} errors
+ * @returns {AutoconsentProfileSummary}
+ */
+function combineProfileSummaries(summaries, errors) {
+    /** @type {Map<string, AutoconsentProfileFunctionSummary>} */
+    const functionsByKey = new Map();
+    let totalProfiledTimeMs = 0;
+    let autoconsentScriptTimeMs = 0;
+    let autoconsentSelfTimeMs = 0;
+    let totalSampleCount = 0;
+    let autoconsentSampleCount = 0;
+
+    for (const summary of summaries) {
+        totalProfiledTimeMs += summary.totalProfiledTimeMs;
+        autoconsentScriptTimeMs += summary.autoconsentScriptTimeMs;
+        autoconsentSelfTimeMs += summary.autoconsentSelfTimeMs;
+        totalSampleCount += summary.totalSampleCount;
+        autoconsentSampleCount += summary.autoconsentSampleCount;
+
+        for (const functionSummary of summary.topFunctions) {
+            const key = [
+                functionSummary.functionName,
+                functionSummary.url,
+                functionSummary.lineNumber,
+                functionSummary.columnNumber,
+            ].join(':');
+            if (!functionsByKey.has(key)) {
+                functionsByKey.set(key, {
+                    ...functionSummary,
+                    selfTimeMs: 0,
+                    totalTimeMs: 0,
+                    hitCount: 0,
+                });
+            }
+            const combinedFunctionSummary = functionsByKey.get(key);
+            combinedFunctionSummary.selfTimeMs += functionSummary.selfTimeMs;
+            combinedFunctionSummary.totalTimeMs += functionSummary.totalTimeMs;
+            combinedFunctionSummary.hitCount += functionSummary.hitCount;
+        }
+    }
+
+    const topFunctions = Array.from(functionsByKey.values())
+        .map((functionSummary) => ({
+            ...functionSummary,
+            selfTimeMs: roundMs(functionSummary.selfTimeMs),
+            totalTimeMs: roundMs(functionSummary.totalTimeMs),
+        }))
+        .sort((a, b) => b.selfTimeMs - a.selfTimeMs || b.totalTimeMs - a.totalTimeMs)
+        .slice(0, PROFILE_TOP_FUNCTIONS_LIMIT);
+
+    return {
+        enabled: true,
+        profileCount: summaries.length,
+        errors,
+        totalProfiledTimeMs: roundMs(totalProfiledTimeMs),
+        autoconsentScriptTimeMs: roundMs(autoconsentScriptTimeMs),
+        autoconsentSelfTimeMs: roundMs(autoconsentSelfTimeMs),
+        totalSampleCount,
+        autoconsentSampleCount,
+        topFunctions,
+    };
+}
 
 class CookiePopupsCollector extends ContentScriptCollector {
     collectorExtraTimeMs = SCRAPE_TIMEOUT + DETECT_TIMEOUT + FOUND_TIMEOUT + OPTOUT_TIMEOUT; // Autoconsent opt-out/opt-in and scraping can take a while
@@ -68,17 +277,89 @@ class CookiePopupsCollector extends ContentScriptCollector {
         this.mainFrameIds = new Set();
         /** @type {Map<string, { frameId: string, isMainFrame: boolean }>} */
         this.contextFrameInfo = new Map();
+        this.profileAutoconsent = Boolean(options.collectorFlags.autoconsentProfile);
+        /** @type {Map<import('devtools-protocol/types/protocol').Protocol.Target.TargetID, AutoconsentProfileState>} */
+        this.autoconsentProfiles = new Map();
     }
 
     /**
      * @param {import('puppeteer-core').CDPSession} session
      * @param {import('devtools-protocol/types/protocol').Protocol.Target.TargetInfo} targetInfo
      */
-    addTarget(session, targetInfo) {
+    async addTarget(session, targetInfo) {
         if (targetInfo.type === 'page') {
             this.mainFrameIds.add(targetInfo.targetId);
         }
         super.addTarget(session, targetInfo);
+        if (this.profileAutoconsent && (targetInfo.type === 'page' || targetInfo.type === 'iframe')) {
+            await this.startAutoconsentProfile(session, targetInfo);
+        }
+    }
+
+    /**
+     * @param {import('puppeteer-core').CDPSession} session
+     * @param {import('devtools-protocol/types/protocol').Protocol.Target.TargetInfo} targetInfo
+     * @returns {Promise<void>}
+     */
+    async startAutoconsentProfile(session, targetInfo) {
+        /** @type {AutoconsentProfileState} */
+        const profileState = {
+            targetId: targetInfo.targetId,
+            targetType: targetInfo.type,
+            url: targetInfo.url,
+            session,
+            started: false,
+            errors: [],
+        };
+        this.autoconsentProfiles.set(targetInfo.targetId, profileState);
+
+        try {
+            await session.send('Profiler.enable');
+            await session.send('Profiler.setSamplingInterval', { interval: PROFILER_SAMPLING_INTERVAL_US });
+            await session.send('Profiler.start');
+            profileState.started = true;
+        } catch (e) {
+            const error = `Could not start Autoconsent CPU profile for ${targetInfo.targetId}: ${e.message || e}`;
+            profileState.errors.push(error);
+            this.log(error);
+        }
+    }
+
+    /**
+     * @returns {Promise<AutoconsentProfileSummary | null>}
+     */
+    async stopAutoconsentProfiles() {
+        if (!this.profileAutoconsent) {
+            return null;
+        }
+
+        /** @type {AutoconsentProfileSummary[]} */
+        const summaries = [];
+        /** @type {string[]} */
+        const errors = [];
+
+        for (const profileState of this.autoconsentProfiles.values()) {
+            errors.push(...profileState.errors);
+            if (!profileState.started) {
+                continue;
+            }
+            try {
+                const { profile } = await profileState.session.send('Profiler.stop');
+                summaries.push(summarizeProfile(profile));
+            } catch (e) {
+                const error = `Could not stop Autoconsent CPU profile for ${profileState.targetId}: ${e.message || e}`;
+                errors.push(error);
+                this.log(error);
+            } finally {
+                try {
+                    await profileState.session.send('Profiler.disable');
+                } catch {
+                    // ignore profiler cleanup errors
+                }
+            }
+        }
+
+        return combineProfileSummaries(summaries, errors);
     }
 
     /**
@@ -535,10 +816,16 @@ class CookiePopupsCollector extends ContentScriptCollector {
         }
 
         const scrapedFrames = await timeboxedScrapeJob;
-        return {
+        const autoconsentProfile = await this.stopAutoconsentProfiles();
+        const result = {
             cmps,
             scrapedFrames,
         };
+        if (autoconsentProfile) {
+            result.autoconsentScriptTimeMs = autoconsentProfile.autoconsentScriptTimeMs;
+            result.autoconsentProfile = autoconsentProfile;
+        }
+        return result;
     }
 }
 
@@ -546,6 +833,8 @@ class CookiePopupsCollector extends ContentScriptCollector {
  * @typedef CookiePopupsCollectorResult
  * @property {AutoconsentResult[]} cmps
  * @property {ScrapeScriptResult[]} scrapedFrames
+ * @property {number=} autoconsentScriptTimeMs
+ * @property {AutoconsentProfileSummary=} autoconsentProfile
  */
 
 /**
@@ -605,6 +894,31 @@ class CookiePopupsCollector extends ContentScriptCollector {
  * @typedef { import('../node_modules/@duckduckgo/autoconsent/lib/messages').OptInResultMessage } OptInResultMessage
  * @typedef { import('../node_modules/@duckduckgo/autoconsent/lib/messages').DoneMessage } DoneMessage
  * @typedef { { snippets: Set<string>, patterns: Set<string>, filterListMatched: boolean } } ScanResult
+ * @typedef AutoconsentProfileState
+ * @property {import('devtools-protocol/types/protocol').Protocol.Target.TargetID} targetId
+ * @property {string} targetType
+ * @property {string} url
+ * @property {import('puppeteer-core').CDPSession} session
+ * @property {boolean} started
+ * @property {string[]} errors
+ * @typedef AutoconsentProfileSummary
+ * @property {boolean=} enabled
+ * @property {number=} profileCount
+ * @property {string[]=} errors
+ * @property {number} totalProfiledTimeMs
+ * @property {number} autoconsentScriptTimeMs
+ * @property {number} autoconsentSelfTimeMs
+ * @property {number} totalSampleCount
+ * @property {number} autoconsentSampleCount
+ * @property {AutoconsentProfileFunctionSummary[]} topFunctions
+ * @typedef AutoconsentProfileFunctionSummary
+ * @property {string} functionName
+ * @property {string} url
+ * @property {number} lineNumber
+ * @property {number} columnNumber
+ * @property {number} selfTimeMs
+ * @property {number} totalTimeMs
+ * @property {number} hitCount
  */
 
 module.exports = CookiePopupsCollector;

--- a/collectors/CookiePopupsCollector.js
+++ b/collectors/CookiePopupsCollector.js
@@ -55,12 +55,7 @@ function roundMs(value) {
  */
 function getProfileNodeKey(node) {
     const callFrame = node.callFrame;
-    return [
-        callFrame.functionName || '(anonymous)',
-        callFrame.url || '',
-        callFrame.lineNumber,
-        callFrame.columnNumber,
-    ].join(':');
+    return [callFrame.functionName || '(anonymous)', callFrame.url || '', callFrame.lineNumber, callFrame.columnNumber].join(':');
 }
 
 /**
@@ -202,12 +197,9 @@ function combineProfileSummaries(summaries, errors) {
         autoconsentSampleCount += summary.autoconsentSampleCount;
 
         for (const functionSummary of summary.topFunctions) {
-            const key = [
-                functionSummary.functionName,
-                functionSummary.url,
-                functionSummary.lineNumber,
-                functionSummary.columnNumber,
-            ].join(':');
+            const key = [functionSummary.functionName, functionSummary.url, functionSummary.lineNumber, functionSummary.columnNumber].join(
+                ':',
+            );
             if (!functionsByKey.has(key)) {
                 functionsByKey.set(key, {
                     ...functionSummary,

--- a/helpers/timer.js
+++ b/helpers/timer.js
@@ -11,6 +11,10 @@ function createTimer() {
 
     return {
         getElapsedTime: () => parseHrtimeToSeconds(process.hrtime(startTime)),
+        getElapsedTimeMs: () => {
+            const hrtime = process.hrtime(startTime);
+            return hrtime[0] * 1000 + hrtime[1] / 1e6;
+        },
     };
 }
 

--- a/reporters/ClickhouseReporter.js
+++ b/reporters/ClickhouseReporter.js
@@ -69,6 +69,32 @@ const TABLE_DEFINITIONS = [
         regexPopupDetected Bool DEFAULT false
     ) ENGINE = ReplicatedMergeTree
     PRIMARY KEY(crawlId, pageId, name)`,
+    `CREATE TABLE IF NOT EXISTS autoconsentPerformance ON CLUSTER 'ch-prod-cluster' (
+        crawlId String,
+        pageId String,
+        enabled Bool,
+        profileCount UInt32,
+        errors Array(String),
+        totalProfiledTimeMs Float64,
+        autoconsentScriptTimeMs Float64,
+        autoconsentSelfTimeMs Float64,
+        totalSampleCount UInt32,
+        autoconsentSampleCount UInt32
+    ) ENGINE = ReplicatedMergeTree
+    PRIMARY KEY(crawlId, pageId)`,
+    `CREATE TABLE IF NOT EXISTS autoconsentProfileFunctions ON CLUSTER 'ch-prod-cluster' (
+        crawlId String,
+        pageId String,
+        functionId UInt32,
+        functionName String,
+        url String,
+        lineNumber Int32,
+        columnNumber Int32,
+        selfTimeMs Float64,
+        totalTimeMs Float64,
+        hitCount UInt32
+    ) ENGINE = ReplicatedMergeTree
+    PRIMARY KEY(crawlId, pageId, functionId)`,
     `CREATE TABLE IF NOT EXISTS apiSavedCalls ON CLUSTER 'ch-prod-cluster' (
         crawlId String,
         pageId String,
@@ -133,6 +159,8 @@ class ClickhouseReporter extends BaseReporter {
             elements: [],
             apiSavedCalls: [],
             cmps: [],
+            autoconsentPerformance: [],
+            autoconsentProfileFunctions: [],
             apiCallStats: [],
             cookies: [],
             targets: [],
@@ -250,6 +278,35 @@ class ClickhouseReporter extends BaseReporter {
                     regexPopupDetected,
                 ]);
                 this.queue.cmps = this.queue.cmps.concat(cmpRows);
+                if (data.data.cookiepopups.autoconsentProfile) {
+                    const { autoconsentProfile } = data.data.cookiepopups;
+                    this.queue.autoconsentPerformance.push([
+                        this.crawlId,
+                        pageId,
+                        autoconsentProfile.enabled || false,
+                        autoconsentProfile.profileCount || 0,
+                        autoconsentProfile.errors || [],
+                        autoconsentProfile.totalProfiledTimeMs,
+                        autoconsentProfile.autoconsentScriptTimeMs,
+                        autoconsentProfile.autoconsentSelfTimeMs,
+                        autoconsentProfile.totalSampleCount,
+                        autoconsentProfile.autoconsentSampleCount,
+                    ]);
+                    this.queue.autoconsentProfileFunctions = this.queue.autoconsentProfileFunctions.concat(
+                        (autoconsentProfile.topFunctions || []).map((profileFunction, functionId) => [
+                            this.crawlId,
+                            pageId,
+                            functionId,
+                            profileFunction.functionName,
+                            profileFunction.url,
+                            profileFunction.lineNumber,
+                            profileFunction.columnNumber,
+                            profileFunction.selfTimeMs,
+                            profileFunction.totalTimeMs,
+                            profileFunction.hitCount,
+                        ]),
+                    );
+                }
             }
             if (data.data.apis) {
                 const { callStats, savedCalls } = data.data.apis;

--- a/tests/cli/crawlConfig.test.js
+++ b/tests/cli/crawlConfig.test.js
@@ -40,6 +40,8 @@ assert(result1.disableAntiBot === mockConfigFile.disableAntiBot, "Correct value 
 assert(result1.proxyConfig === mockConfigFile.proxyConfig, "Correct value for 'proxyConfig'");
 assert(result1.regionCode === mockConfigFile.regionCode, "Correct value for 'regionCode'");
 assert(result1.chromiumVersion === mockConfigFile.chromiumVersion, "Correct value for 'chromiumVersion'");
+assert(result1.autoconsentAction === mockConfigFile.autoconsentAction, "Correct value for 'autoconsentAction'");
+assert(result1.autoconsentProfile === mockConfigFile.autoconsentProfile, "Correct value for 'autoconsentProfile'");
 assert(result1.maxLoadTimeMs === mockConfigFile.maxLoadTimeMs, "Correct value for 'maxLoadTimeMs'");
 assert(result1.extraExecutionTimeMs === mockConfigFile.extraExecutionTimeMs, "Correct value for 'extraExecutionTimeMs'");
 assert.deepStrictEqual(result1.dataCollectors, mockConfigFile.dataCollectors, "Correct value for 'dataCollectors'");
@@ -67,6 +69,8 @@ const flags = {
     proxyConfig: 'something:else:13',
     regionCode: 'KA',
     chromiumVersion: '987654',
+    autoconsentAction: 'optIn',
+    autoconsentProfile: false,
     dataCollectors: 'targets,cookies',
     reporters: 'html,file',
 };
@@ -84,6 +88,8 @@ assert(result2.disableAntiBot === flags.disableAntiBot, "Correct value for 'disa
 assert(result2.proxyConfig === flags.proxyConfig, "Correct value for 'proxyConfig'");
 assert(result2.regionCode === flags.regionCode, "Correct value for 'regionCode'");
 assert(result2.chromiumVersion === flags.chromiumVersion, "Correct value for 'chromiumVersion'");
+assert(result2.autoconsentAction === flags.autoconsentAction, "Correct value for 'autoconsentAction'");
+assert(result2.autoconsentProfile === flags.autoconsentProfile, "Correct value for 'autoconsentProfile'");
 assert(result2.maxLoadTimeMs === mockConfigFile.maxLoadTimeMs, "Correct value for 'maxLoadTimeMs'");
 assert(result2.extraExecutionTimeMs === mockConfigFile.extraExecutionTimeMs, "Correct value for 'extraExecutionTimeMs'");
 assert.deepStrictEqual(result2.dataCollectors, ['targets', 'cookies'], "Correct value for 'dataCollectors'");

--- a/tests/cli/sampleConfig.json
+++ b/tests/cli/sampleConfig.json
@@ -12,6 +12,8 @@
     "proxyConfig": "bla:bla:123",
     "regionCode": "PL",
     "chromiumVersion": "123456",
+    "autoconsentAction": "optOut",
+    "autoconsentProfile": true,
     "dataCollectors": ["requests", "apis", "screenshots"],
     "reporters": ["cli"],
     "urls": ["https://five.test", "six.test", { "url": "seven.test" }, { "url": "one.test", "dataCollectors": ["targets"] }]

--- a/tests/collectors/CookiePopupsCollector.mocha.js
+++ b/tests/collectors/CookiePopupsCollector.mocha.js
@@ -751,4 +751,121 @@ describe('CookiePopupsCollector', () => {
             assert.strictEqual(data.scrapedFrames.flatMap((frame) => frame.potentialPopups).length, 0);
         });
     });
+
+    describe('autoconsent CDP profile', () => {
+        it('should summarize time spent in the autoconsent script', async () => {
+            const profileCommands = [];
+            const mockSession = {
+                send: sinon.stub().callsFake(async (command, payload) => {
+                    profileCommands.push([command, payload]);
+                    if (command === 'Profiler.stop') {
+                        return {
+                            profile: {
+                                startTime: 0,
+                                endTime: 23000,
+                                nodes: [
+                                    {
+                                        id: 1,
+                                        callFrame: {
+                                            functionName: '(root)',
+                                            scriptId: '0',
+                                            url: '',
+                                            lineNumber: 0,
+                                            columnNumber: 0,
+                                        },
+                                        children: [2, 4],
+                                    },
+                                    {
+                                        id: 2,
+                                        callFrame: {
+                                            functionName: 'detectCMP',
+                                            scriptId: '1',
+                                            url: 'duckduckgo-autoconsent.js',
+                                            lineNumber: 10,
+                                            columnNumber: 2,
+                                        },
+                                        children: [3],
+                                    },
+                                    {
+                                        id: 3,
+                                        callFrame: {
+                                            functionName: 'querySelectorAll',
+                                            scriptId: '2',
+                                            url: '',
+                                            lineNumber: 0,
+                                            columnNumber: 0,
+                                        },
+                                    },
+                                    {
+                                        id: 4,
+                                        callFrame: {
+                                            functionName: 'siteScript',
+                                            scriptId: '3',
+                                            url: 'https://example.com/site.js',
+                                            lineNumber: 1,
+                                            columnNumber: 1,
+                                        },
+                                    },
+                                ],
+                                samples: [2, 3, 4],
+                                timeDeltas: [5000, 7000, 11000],
+                            },
+                        };
+                    }
+                    if (command === 'Runtime.evaluate') {
+                        return { result: { value: null } };
+                    }
+                    return {};
+                }),
+                on: sinon.stub(),
+            };
+
+            collector = new CookiePopupsCollector();
+            // @ts-ignore no need to provide all params
+            collector.init({
+                log: () => {},
+                collectorFlags: {
+                    shortTimeouts: true,
+                    autoconsentProfile: true,
+                },
+            });
+            // @ts-expect-error passing mock objects
+            await collector.addTarget(mockSession, { type: 'page', url: 'https://example.com', targetId: 'profile-target' });
+
+            const data = await collector.getData();
+
+            assert.deepStrictEqual(
+                profileCommands.slice(0, 3),
+                [
+                    ['Profiler.enable', undefined],
+                    ['Profiler.setSamplingInterval', { interval: 1000 }],
+                    ['Profiler.start', undefined],
+                ],
+            );
+            assert(profileCommands.some(([command]) => command === 'Profiler.stop'), 'profile should be stopped');
+            assert(profileCommands.some(([command]) => command === 'Profiler.disable'), 'profiler should be disabled');
+            assert.strictEqual(data.autoconsentScriptTimeMs, 12);
+            assert.deepStrictEqual(data.autoconsentProfile, {
+                enabled: true,
+                profileCount: 1,
+                errors: [],
+                totalProfiledTimeMs: 23,
+                autoconsentScriptTimeMs: 12,
+                autoconsentSelfTimeMs: 5,
+                totalSampleCount: 3,
+                autoconsentSampleCount: 2,
+                topFunctions: [
+                    {
+                        functionName: 'detectCMP',
+                        url: 'duckduckgo-autoconsent.js',
+                        lineNumber: 10,
+                        columnNumber: 2,
+                        selfTimeMs: 5,
+                        totalTimeMs: 12,
+                        hitCount: 1,
+                    },
+                ],
+            });
+        });
+    });
 });

--- a/tests/collectors/CookiePopupsCollector.mocha.js
+++ b/tests/collectors/CookiePopupsCollector.mocha.js
@@ -834,16 +834,19 @@ describe('CookiePopupsCollector', () => {
 
             const data = await collector.getData();
 
-            assert.deepStrictEqual(
-                profileCommands.slice(0, 3),
-                [
-                    ['Profiler.enable', undefined],
-                    ['Profiler.setSamplingInterval', { interval: 1000 }],
-                    ['Profiler.start', undefined],
-                ],
+            assert.deepStrictEqual(profileCommands.slice(0, 3), [
+                ['Profiler.enable', undefined],
+                ['Profiler.setSamplingInterval', { interval: 1000 }],
+                ['Profiler.start', undefined],
+            ]);
+            assert(
+                profileCommands.some(([command]) => command === 'Profiler.stop'),
+                'profile should be stopped',
             );
-            assert(profileCommands.some(([command]) => command === 'Profiler.stop'), 'profile should be stopped');
-            assert(profileCommands.some(([command]) => command === 'Profiler.disable'), 'profiler should be disabled');
+            assert(
+                profileCommands.some(([command]) => command === 'Profiler.disable'),
+                'profiler should be disabled',
+            );
             assert.strictEqual(data.autoconsentScriptTimeMs, 12);
             assert.deepStrictEqual(data.autoconsentProfile, {
                 enabled: true,

--- a/tests/reporters/ClickhouseReporter.test.js
+++ b/tests/reporters/ClickhouseReporter.test.js
@@ -1,0 +1,92 @@
+const assert = require('assert');
+const mockery = require('mockery');
+const { createUniqueUrlName } = require('../../helpers/hash');
+
+const queries = [];
+const inserts = [];
+
+mockery.enable({
+    warnOnUnregistered: false,
+});
+mockery.registerMock('@clickhouse/client', {
+    createClient: () => ({
+        query: async ({ query }) => {
+            queries.push(query);
+            return {};
+        },
+        insert: async ({ table, values }) => {
+            inserts.push({ table, values });
+            return {};
+        },
+    }),
+});
+
+const ClickhouseReporter = require('../../reporters/ClickhouseReporter');
+
+async function main() {
+    const reporter = new ClickhouseReporter();
+    reporter.init({ verbose: false });
+    reporter.crawlId = 'test-crawl-id';
+
+    const initialUrl = 'https://example.com/path';
+    const pageId = createUniqueUrlName(new URL(initialUrl));
+    await reporter.processSite({
+        initialUrl,
+        finalUrl: initialUrl,
+        timeout: false,
+        testStarted: 1710000000000,
+        testFinished: 1710000001000,
+        data: {
+            cookiepopups: {
+                cmps: [],
+                scrapedFrames: [],
+                autoconsentScriptTimeMs: 12,
+                autoconsentProfile: {
+                    enabled: true,
+                    profileCount: 1,
+                    errors: ['profiler error'],
+                    totalProfiledTimeMs: 23,
+                    autoconsentScriptTimeMs: 12,
+                    autoconsentSelfTimeMs: 5,
+                    totalSampleCount: 3,
+                    autoconsentSampleCount: 2,
+                    topFunctions: [
+                        {
+                            functionName: 'detectCMP',
+                            url: 'duckduckgo-autoconsent.js',
+                            lineNumber: 10,
+                            columnNumber: 2,
+                            selfTimeMs: 5,
+                            totalTimeMs: 12,
+                            hitCount: 1,
+                        },
+                    ],
+                },
+            },
+        },
+    });
+    await reporter.cleanup();
+
+    assert(
+        queries.some((query) => query.includes('CREATE TABLE IF NOT EXISTS autoconsentPerformance')),
+        'autoconsentPerformance table should be created',
+    );
+    assert(
+        queries.some((query) => query.includes('CREATE TABLE IF NOT EXISTS autoconsentProfileFunctions')),
+        'autoconsentProfileFunctions table should be created',
+    );
+
+    const performanceInsert = inserts.find((insert) => insert.table === 'autoconsentPerformance');
+    assert.deepStrictEqual(performanceInsert.values, [
+        ['test-crawl-id', pageId, true, 1, ['profiler error'], 23, 12, 5, 3, 2],
+    ]);
+
+    const functionInsert = inserts.find((insert) => insert.table === 'autoconsentProfileFunctions');
+    assert.deepStrictEqual(functionInsert.values, [
+        ['test-crawl-id', pageId, 0, 'detectCMP', 'duckduckgo-autoconsent.js', 10, 2, 5, 12, 1],
+    ]);
+
+    mockery.disable();
+}
+
+main();

--- a/tests/reporters/ClickhouseReporter.test.js
+++ b/tests/reporters/ClickhouseReporter.test.js
@@ -77,9 +77,7 @@ async function main() {
     );
 
     const performanceInsert = inserts.find((insert) => insert.table === 'autoconsentPerformance');
-    assert.deepStrictEqual(performanceInsert.values, [
-        ['test-crawl-id', pageId, true, 1, ['profiler error'], 23, 12, 5, 3, 2],
-    ]);
+    assert.deepStrictEqual(performanceInsert.values, [['test-crawl-id', pageId, true, 1, ['profiler error'], 23, 12, 5, 3, 2]]);
 
     const functionInsert = inserts.find((insert) => insert.table === 'autoconsentProfileFunctions');
     assert.deepStrictEqual(functionInsert.values, [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add an opt-in `autoconsentProfile` collector flag and `--autoconsent-profile` CLI/config support.
- Start CDP CPU profiling for page/iframe targets while the cookie popups collector runs.
- Summarize profile samples attributable to the injected autoconsent script and expose top-level `autoconsentScriptTimeMs` plus an `autoconsentProfile` summary in collector output.
- Export autoconsent profile summaries to ClickHouse via `autoconsentPerformance` and top function rows via `autoconsentProfileFunctions`.
- Add focused unit coverage for the profile summary output, config parsing, and ClickHouse reporter export.

## Testing
- `node ./tests/reporters/ClickhouseReporter.test.js`
- `npm run eslint`
- `npm run prettier -- --check`
- `npm test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e24b033-3afc-4620-98cd-7b69b75d204f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e24b033-3afc-4620-98cd-7b69b75d204f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

