### PR TITLE
Export autoconsent performance stats into CPM clickhouse tables.

### DIFF
--- a/collectors/CookiePopupsCollector.js
+++ b/collectors/CookiePopupsCollector.js
@@ -36,6 +36,24 @@ window.autoconsentSendMessage = (msg) => {
 
 const cookiePopupScrapeScript = fs.readFileSync(require.resolve('./CookiePopups/scrapeScript.js'), 'utf8');
 
+/**
+ * @param {string} url
+ * @returns {string}
+ */
+function normalizeFrameUrl(url) {
+    if (!url) {
+        return '';
+    }
+    try {
+        const parsed = new URL(url);
+        parsed.search = '';
+        parsed.hash = '';
+        return parsed.href;
+    } catch {
+        return url.split('?')[0].split('#')[0];
+    }
+}
+
 class CookiePopupsCollector extends ContentScriptCollector {
     collectorExtraTimeMs = SCRAPE_TIMEOUT + DETECT_TIMEOUT + FOUND_TIMEOUT + OPTOUT_TIMEOUT; // Autoconsent opt-out/opt-in and scraping can take a while
 
@@ -68,6 +86,8 @@ class CookiePopupsCollector extends ContentScriptCollector {
         this.mainFrameIds = new Set();
         /** @type {Map<string, { frameId: string, isMainFrame: boolean }>} */
         this.contextFrameInfo = new Map();
+        /** @type {Map<string, AutoconsentPerformanceResult>} */
+        this.performanceResults = new Map();
     }
 
     /**
@@ -184,6 +204,7 @@ class CookiePopupsCollector extends ContentScriptCollector {
                     enableHeuristicAction: true,
                     detectRetries: 20,
                     isMainWorld: false,
+                    performanceLoggingEnabled: true,
                 };
                 const frameInfo = this.contextFrameInfo.get(executionContextUniqueId);
                 const isMainFrame = frameInfo?.isMainFrame ?? true;
@@ -226,6 +247,18 @@ class CookiePopupsCollector extends ContentScriptCollector {
             case 'report':
                 msg.state.heuristicPatterns.forEach((x) => this.scanResult.patterns.add(x));
                 msg.state.heuristicSnippets.forEach((x) => this.scanResult.snippets.add(x));
+                if (msg.state.performance) {
+                    const frameInfo = this.contextFrameInfo.get(executionContextUniqueId);
+                    const url = normalizeFrameUrl(msg.url || '');
+                    if (!url) {
+                        break;
+                    }
+                    this.performanceResults.set(url, {
+                        url,
+                        isMainFrame: frameInfo?.isMainFrame ?? false,
+                        ...msg.state.performance,
+                    });
+                }
                 break;
             case 'optInResult':
             case 'optOutResult': {
@@ -437,6 +470,23 @@ class CookiePopupsCollector extends ContentScriptCollector {
         return results;
     }
 
+    async collectPerformanceResults() {
+        await Promise.all(
+            Array.from(this.cdpSessions.entries()).map(async ([executionContextUniqueId, session]) => {
+                try {
+                    await session.send('Runtime.evaluate', {
+                        expression: `autoconsentReceiveMessage({ type: "measurePerformance" })`,
+                        uniqueContextId: executionContextUniqueId,
+                    });
+                } catch (e) {
+                    if (!this.isIgnoredCdpError(e)) {
+                        this.log(`Error requesting performance data in ${executionContextUniqueId}: ${e}`);
+                    }
+                }
+            }),
+        );
+    }
+
     /**
      * @returns {Promise<ScrapeScriptResult[]>}
      */
@@ -508,6 +558,7 @@ class CookiePopupsCollector extends ContentScriptCollector {
         const popupFoundTimer = createTimer();
         const popupFound = await this.waitForPopupFound();
         this.log(`Waiting for popupFound took ${popupFoundTimer.getElapsedTime()}s`);
+        await this.collectPerformanceResults();
         if (popupFound && this.autoAction) {
             // make sure we start waiting only after the scrape job is done
             await this.scrapeJobDeferred.promise;
@@ -537,6 +588,7 @@ class CookiePopupsCollector extends ContentScriptCollector {
         const scrapedFrames = await timeboxedScrapeJob;
         return {
             cmps,
+            performance: Array.from(this.performanceResults.values()),
             scrapedFrames,
         };
     }
@@ -545,7 +597,20 @@ class CookiePopupsCollector extends ContentScriptCollector {
 /**
  * @typedef CookiePopupsCollectorResult
  * @property {AutoconsentResult[]} cmps
+ * @property {AutoconsentPerformanceResult[]} performance
  * @property {ScrapeScriptResult[]} scrapedFrames
+ */
+
+/**
+ * @typedef AutoconsentPerformanceResult
+ * @property {string} url
+ * @property {boolean} isMainFrame
+ * @property {number[]} filterCMPs
+ * @property {number[]} detectHeuristics
+ * @property {number[]} heuristicDetector
+ * @property {number[]} findCmpSiteSpecific
+ * @property {number[]} findCmpGeneric
+ * @property {number[]} findCmpHeuristic
  */
 
 /**

--- a/reporters/ClickhouseReporter.js
+++ b/reporters/ClickhouseReporter.js
@@ -100,7 +100,41 @@ const TABLE_DEFINITIONS = [
         type String
     ) ENGINE = ReplicatedMergeTree
     PRIMARY KEY(crawlId, pageId, targetId)`,
+    `CREATE TABLE IF NOT EXISTS autoconsentPerformance ON CLUSTER 'ch-prod-cluster' (
+        crawlId String,
+        pageId String,
+        frameUrl String,
+        isMainFrame UInt8,
+        measurement String,
+        sum Float64,
+        count UInt32
+    ) ENGINE = ReplicatedMergeTree
+    PRIMARY KEY(crawlId, pageId, frameUrl, measurement)`,
 ];
+
+/** @type {readonly string[]} */
+const PERFORMANCE_MEASUREMENTS = [
+    'filterCMPs',
+    'detectHeuristics',
+    'heuristicDetector',
+    'findCmpSiteSpecific',
+    'findCmpGeneric',
+    'findCmpHeuristic',
+];
+
+/**
+ * @param {number[] | undefined} values
+ * @returns {{ sum: number, count: number }}
+ */
+function summarizeMeasurementArray(values) {
+    if (!Array.isArray(values) || values.length === 0) {
+        return { sum: 0, count: 0 };
+    }
+    return {
+        sum: values.reduce((total, value) => total + value, 0),
+        count: values.length,
+    };
+}
 
 /**
  * @param {string | string[]} args
@@ -136,6 +170,7 @@ class ClickhouseReporter extends BaseReporter {
             apiCallStats: [],
             cookies: [],
             targets: [],
+            autoconsentPerformance: [],
         };
     }
 
@@ -250,6 +285,22 @@ class ClickhouseReporter extends BaseReporter {
                     regexPopupDetected,
                 ]);
                 this.queue.cmps = this.queue.cmps.concat(cmpRows);
+
+                const performanceRows = (data.data.cookiepopups.performance || []).flatMap((entry) =>
+                    PERFORMANCE_MEASUREMENTS.map((measurement) => {
+                        const { sum, count } = summarizeMeasurementArray(entry[measurement]);
+                        return [
+                            this.crawlId,
+                            pageId,
+                            entry.url || data.finalUrl || data.initialUrl,
+                            entry.isMainFrame ? 1 : 0,
+                            measurement,
+                            sum,
+                            count,
+                        ];
+                    }),
+                );
+                this.queue.autoconsentPerformance = this.queue.autoconsentPerformance.concat(performanceRows);
             }
             if (data.data.apis) {
                 const { callStats, savedCalls } = data.data.apis;

--- a/tests/collectors/CookiePopupsCollector.mocha.js
+++ b/tests/collectors/CookiePopupsCollector.mocha.js
@@ -101,6 +101,7 @@ describe('CookiePopupsCollector', () => {
                     enableHeuristicAction: true,
                     detectRetries: 20,
                     isMainWorld: false,
+                    performanceLoggingEnabled: true,
                 };
                 const expectedRules = {
                     autoconsent: [],
@@ -139,6 +140,7 @@ describe('CookiePopupsCollector', () => {
                     enableHeuristicAction: true,
                     detectRetries: 20,
                     isMainWorld: false,
+                    performanceLoggingEnabled: true,
                 };
                 const expectedRules = {
                     autoconsent: [],


### PR DESCRIPTION
https://app.asana.com/1/137249556945/project/1163321984198618/task/1215357412614455?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes to crawl collection and reporting; no auth or consent-action logic changes beyond an extra CDP evaluate and new ClickHouse rows.
> 
> **Overview**
> Adds **end-to-end autoconsent performance telemetry** for CPM crawls: the cookie-popup collector turns on autoconsent performance logging, gathers per-frame timing samples, and the ClickHouse reporter stores aggregated stats.
> 
> **CookiePopupsCollector** now sends `performanceLoggingEnabled: true` in the autoconsent init config, stores performance payloads from `report` messages (keyed by normalized frame URL), and after popup detection runs `measurePerformance` across all isolated-world CDP contexts before returning a new `performance` array alongside CMP and scrape results.
> 
> **ClickhouseReporter** defines an `autoconsentPerformance` table and, for each crawl page, writes one row per frame and measurement (`filterCMPs`, `detectHeuristics`, `heuristicDetector`, `findCmpSiteSpecific`, `findCmpGeneric`, `findCmpHeuristic`) with **sum** and **count** derived from the raw timing arrays. Tests expect the updated init config flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 344365f0c5041668ba05eec575ad7b9ce07084b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->