### PR TITLE
fix an edge case in scraping (already in autoconsent)

### DIFF
--- a/collectors/CookiePopups/scrapeScript.js
+++ b/collectors/CookiePopups/scrapeScript.js
@@ -307,7 +307,7 @@ function getButtonData(el) {
         (b) =>
             isVisible(b) &&
             !isDisabled(b) &&
-            (b.innerText.trim() ||
+            (b.innerText?.trim() ||
                 // <input> values do not appear in innerText
                 (b instanceof HTMLInputElement && ['submit', 'button'].includes(b.type) && b.value?.trim())),
     );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single defensive null-safe change in popup button filtering with no auth, data, or API impact.
> 
> **Overview**
> Fixes a cookie-popup scraping crash when classifying actionable buttons: the visibility filter now uses **`innerText?.trim()`** instead of calling **`.trim()`** directly on **`innerText`**.
> 
> This matches the autoconsent fix for elements where **`innerText`** can be missing, so those controls are still evaluated via the existing submit/button **`value`** fallback instead of throwing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e00d0f04e0691deafaeb72b7dfab2cea164dfc35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->